### PR TITLE
fix: Resolve season transition bugs for proper team data carryover

### DIFF
--- a/RCode/interactive_prompts.R
+++ b/RCode/interactive_prompts.R
@@ -67,9 +67,9 @@ require_interactive_mode <- function() {
   return(TRUE)
 }
 
-prompt_for_team_info <- function(team_name, league, existing_short_names = NULL, retry_count = 0) {
+prompt_for_team_info <- function(team_name, league, existing_short_names = NULL, baseline = NULL, retry_count = 0) {
   # Interactive prompt for new team information
-  # Validates input and provides defaults
+  # Validates input and provides defaults with optional baseline for Liga3
   
   # Maximum retry limit to prevent infinite loops
   MAX_RETRIES <- 10
@@ -84,8 +84,8 @@ prompt_for_team_info <- function(team_name, league, existing_short_names = NULL,
   # Get short name
   short_name <- get_team_short_name_interactive(team_name, existing_short_names)
   
-  # Get initial ELO
-  initial_elo <- get_initial_elo_interactive(league)
+  # Get initial ELO (pass baseline for Liga3)
+  initial_elo <- get_initial_elo_interactive(league, baseline)
   
   # Get promotion value (only for Liga3)
   promotion_value <- get_promotion_value_interactive(team_name, league)
@@ -101,7 +101,7 @@ prompt_for_team_info <- function(team_name, league, existing_short_names = NULL,
     confirmed <- confirm_action("Is this information correct? (y/n): ", default = "y")
     if (!confirmed) {
       cat("Please re-enter team information.\n")
-      return(prompt_for_team_info(team_name, league, existing_short_names, retry_count + 1))
+      return(prompt_for_team_info(team_name, league, existing_short_names, baseline, retry_count + 1))
     }
   }
   
@@ -177,11 +177,11 @@ get_team_short_name_interactive <- function(team_name, existing_short_names = NU
   return(toupper(short_name))
 }
 
-get_initial_elo_interactive <- function(league) {
+get_initial_elo_interactive <- function(league, baseline = NULL) {
   # Interactive prompt for initial ELO
-  # Provides league-appropriate defaults
+  # Provides league-appropriate defaults with optional baseline
   
-  default_elo <- get_initial_elo_for_new_team(league)
+  default_elo <- get_initial_elo_for_new_team(league, baseline)
   
   while (TRUE) {
     if (check_interactive_mode()) {

--- a/RCode/team_data_carryover.R
+++ b/RCode/team_data_carryover.R
@@ -1,0 +1,173 @@
+# Team Data Carryover Module
+# Handles loading and matching team data from previous seasons
+
+# Source required modules
+source("RCode/file_operations.R")
+
+load_previous_team_list <- function(season) {
+  # Load TeamList for specified season
+  # Returns data frame or NULL if not found
+  
+  tryCatch({
+    team_list_file <- paste0("RCode/TeamList_", season, ".csv")
+    
+    if (!file.exists(team_list_file)) {
+      warning(paste("TeamList file not found for season", season))
+      return(NULL)
+    }
+    
+    # Read using safe file read
+    team_data <- safe_file_read(team_list_file, sep = ";", header = TRUE)
+    
+    if (is.null(team_data)) {
+      warning(paste("Could not read TeamList for season", season))
+      return(NULL)
+    }
+    
+    # Validate required columns
+    required_cols <- c("TeamID", "ShortText", "Promotion", "InitialELO")
+    if (!all(required_cols %in% colnames(team_data))) {
+      warning(paste("TeamList for season", season, "missing required columns"))
+      return(NULL)
+    }
+    
+    return(team_data)
+    
+  }, error = function(e) {
+    warning(paste("Error loading TeamList for season", season, ":", e$message))
+    return(NULL)
+  })
+}
+
+get_existing_team_data <- function(team_id, previous_team_list) {
+  # Get team data from previous season by TeamID
+  # Returns list with short_name and promotion_value or NULL
+  
+  if (is.null(previous_team_list) || nrow(previous_team_list) == 0) {
+    return(NULL)
+  }
+  
+  # Find team by ID
+  team_row <- previous_team_list[previous_team_list$TeamID == team_id, ]
+  
+  if (nrow(team_row) == 0) {
+    return(NULL)
+  }
+  
+  return(list(
+    short_name = as.character(team_row$ShortText[1]),
+    promotion_value = as.numeric(team_row$Promotion[1])
+  ))
+}
+
+build_team_lookup_table <- function(previous_team_list) {
+  # Build lookup table for fast team data access
+  # Returns named list: TeamID -> list(short_name, promotion_value)
+  
+  if (is.null(previous_team_list) || nrow(previous_team_list) == 0) {
+    return(list())
+  }
+  
+  lookup <- list()
+  
+  for (i in 1:nrow(previous_team_list)) {
+    team_id <- as.character(previous_team_list$TeamID[i])
+    lookup[[team_id]] <- list(
+      short_name = as.character(previous_team_list$ShortText[i]),
+      promotion_value = as.numeric(previous_team_list$Promotion[i])
+    )
+  }
+  
+  return(lookup)
+}
+
+validate_short_name_uniqueness <- function(short_names) {
+  # Check if all short names are unique
+  # Returns validation result
+  
+  duplicates <- short_names[duplicated(short_names)]
+  
+  if (length(duplicates) > 0) {
+    return(list(
+      valid = FALSE,
+      message = paste("Duplicate short names found:", paste(unique(duplicates), collapse = ", ")),
+      duplicates = unique(duplicates)
+    ))
+  }
+  
+  return(list(
+    valid = TRUE,
+    message = "All short names are unique"
+  ))
+}
+
+merge_team_data_with_carryover <- function(new_teams, previous_team_list, final_elos) {
+  # Merge new team data with carryover from previous season
+  # Returns merged team list
+  
+  if (is.null(previous_team_list)) {
+    warning("No previous team list available for carryover")
+    return(new_teams)
+  }
+  
+  # Build lookup table for efficiency
+  team_lookup <- build_team_lookup_table(previous_team_list)
+  
+  # Process each team
+  for (i in seq_along(new_teams)) {
+    team <- new_teams[[i]]
+    team_id_str <- as.character(team$id)
+    
+    # Check if team existed in previous season
+    if (team_id_str %in% names(team_lookup)) {
+      # Carry over short name and promotion value
+      previous_data <- team_lookup[[team_id_str]]
+      new_teams[[i]]$short_name <- previous_data$short_name
+      new_teams[[i]]$promotion_value <- previous_data$promotion_value
+      
+      # Get final ELO if available
+      if (!is.null(final_elos)) {
+        team_elo <- final_elos$FinalELO[final_elos$TeamID == team$id]
+        if (length(team_elo) > 0) {
+          new_teams[[i]]$initial_elo <- team_elo[1]
+        }
+      }
+    }
+  }
+  
+  return(new_teams)
+}
+
+ensure_unique_short_names <- function(teams) {
+  # Ensure all teams have unique short names
+  # Returns teams with guaranteed unique short names
+  
+  short_names <- sapply(teams, function(t) t$short_name)
+  validation <- validate_short_name_uniqueness(short_names)
+  
+  if (!validation$valid) {
+    # Fix duplicates by appending numbers
+    for (dup in validation$duplicates) {
+      indices <- which(short_names == dup)
+      if (length(indices) > 1) {
+        # Keep first occurrence, modify others
+        for (j in 2:length(indices)) {
+          idx <- indices[j]
+          counter <- 1
+          new_name <- paste0(substr(dup, 1, 2), counter)
+          
+          # Find unique name
+          while (new_name %in% short_names) {
+            counter <- counter + 1
+            new_name <- paste0(substr(dup, 1, 2), counter)
+          }
+          
+          teams[[idx]]$short_name <- new_name
+          short_names[idx] <- new_name
+        }
+      }
+    }
+  }
+  
+  return(teams)
+}

--- a/run_linting.R
+++ b/run_linting.R
@@ -2,7 +2,7 @@
 library(lintr)
 
 # Lint all implemented modules
-lint_files <- list.files('RCode', pattern = '(season_|api_|interactive_|input_|csv_|file_|league_|error_|logging|team_config_loader)\\.R$', full.names = TRUE)
+lint_files <- list.files('RCode', pattern = '(season_|api_|interactive_|input_|csv_|file_|league_|error_|logging|team_config_loader|team_data_carryover)\\.R$', full.names = TRUE)
 lint_files <- c(lint_files, 'scripts/season_transition.R')
 
 total_issues <- 0

--- a/tests/testthat/test-season-processor.R
+++ b/tests/testthat/test-season-processor.R
@@ -1,0 +1,258 @@
+# Test suite for season processor functionality
+
+library(testthat)
+library(mockery)
+
+# Skip sourcing if already loaded or use conditional sourcing
+if (!exists("process_league_teams")) {
+  # Try to source from test environment
+  tryCatch({
+    source("../../RCode/season_processor.R")
+    source("../../RCode/team_data_carryover.R")
+  }, error = function(e) {
+    # Skip if files not found - functions might be loaded differently
+    warning("Could not source files, assuming functions are already loaded")
+  })
+}
+
+context("Season Processor - Team Data Carryover")
+
+test_that("process_league_teams carries over ShortText from previous season", {
+  # Setup: Create mock previous season data
+  prev_season_data <- data.frame(
+    TeamID = c(168, 167, 165),
+    ShortText = c("B04", "HOF", "BVB"),
+    Promotion = c(0, 0, 0),
+    InitialELO = c(1765, 1628, 1885),
+    stringsAsFactors = FALSE
+  )
+  
+  # Mock API response with same teams
+  api_teams <- list(
+    list(id = 168, name = "Bayer Leverkusen", is_second_team = FALSE),
+    list(id = 167, name = "Hoffenheim", is_second_team = FALSE),
+    list(id = 165, name = "Borussia Dortmund", is_second_team = FALSE)
+  )
+  
+  # Mock final ELOs
+  final_elos <- data.frame(
+    TeamID = c(168, 167, 165),
+    FinalELO = c(1800, 1650, 1900)
+  )
+  
+  # Test
+  result <- process_league_teams(api_teams, "78", "2025", final_elos, 1100, prev_season_data)
+  
+  # Extract short names from result
+  short_names <- sapply(result, function(t) t$short_name)
+  team_ids <- sapply(result, function(t) t$id)
+  
+  # Assertions
+  expect_equal(short_names[team_ids == 168], "B04")
+  expect_equal(short_names[team_ids == 167], "HOF")
+  expect_equal(short_names[team_ids == 165], "BVB")
+})
+
+test_that("process_league_teams generates ShortText only for new teams", {
+  # Setup: Previous season has teams 168, 167
+  prev_season_data <- data.frame(
+    TeamID = c(168, 167),
+    ShortText = c("B04", "HOF"),
+    Promotion = c(0, 0),
+    InitialELO = c(1765, 1628),
+    stringsAsFactors = FALSE
+  )
+  
+  # API returns existing teams plus new team 1320
+  api_teams <- list(
+    list(id = 168, name = "Bayer Leverkusen", is_second_team = FALSE),
+    list(id = 1320, name = "Energie Cottbus", is_second_team = FALSE)  # New team
+  )
+  
+  final_elos <- data.frame(
+    TeamID = c(168),
+    FinalELO = c(1800)
+  )
+  
+  # Mock prompt_for_team_info to return FCE for new team
+  mock_prompt <- mock(list(short_name = "FCE", initial_elo = 1100, promotion_value = 0))
+  stub(process_league_teams, "prompt_for_team_info", mock_prompt)
+  
+  # Test
+  result <- process_league_teams(api_teams, "78", "2025", final_elos, 1100, prev_season_data)
+  
+  # Extract data
+  short_names <- sapply(result, function(t) t$short_name)
+  team_ids <- sapply(result, function(t) t$id)
+  
+  # Assertions
+  expect_equal(short_names[team_ids == 168], "B04")  # Existing
+  expect_equal(short_names[team_ids == 1320], "FCE") # New
+  
+  # Verify prompt was called only for new team
+  expect_called(mock_prompt, 1)
+})
+
+test_that("process_league_teams uses final ELO for existing teams", {
+  # Setup
+  prev_season_data <- data.frame(
+    TeamID = c(168),
+    ShortText = c("B04"),
+    Promotion = c(0),
+    InitialELO = c(1765),  # Initial ELO from previous season start
+    stringsAsFactors = FALSE
+  )
+  
+  api_teams <- list(
+    list(id = 168, name = "Bayer Leverkusen", is_second_team = FALSE)
+  )
+  
+  # Final ELO after all matches
+  final_elos <- data.frame(
+    TeamID = c(168),
+    FinalELO = c(1823)  # Different from initial
+  )
+  
+  # Test
+  result <- process_league_teams(api_teams, "78", "2025", final_elos, 1100, prev_season_data)
+  
+  # Assertions
+  expect_equal(result[[1]]$initial_elo, 1823)  # Should use final ELO, not 1765
+})
+
+context("Season Processor - ELO Baseline Passing")
+
+test_that("Liga3 baseline is passed to prompt_for_team_info", {
+  # Setup
+  api_teams <- list(
+    list(id = 1320, name = "Energie Cottbus", is_second_team = FALSE)
+  )
+  
+  final_elos <- data.frame(TeamID = numeric(), FinalELO = numeric())
+  
+  # Mock prompt function to capture baseline
+  captured_baseline <- NULL
+  mock_prompt <- mock(
+    list(short_name = "FCE", initial_elo = 1234, promotion_value = 0),
+    cycle = TRUE
+  )
+  
+  stub(process_league_teams, "prompt_for_team_info", function(name, league, existing, baseline) {
+    captured_baseline <<- baseline
+    mock_prompt()
+  })
+  
+  # Test with baseline 1234
+  process_league_teams(api_teams, "80", "2025", final_elos, 1234, NULL)
+  
+  # Assertions
+  expect_equal(captured_baseline, 1234)
+})
+
+context("Season Processor - Season Validation")
+
+test_that("process_single_season validates previous season completion", {
+  # Mock validation to fail
+  stub(process_single_season, "validate_season_completion", function(season) {
+    stop(sprintf("Season %s not finished, no season transition possible.", season))
+  })
+  
+  # Test
+  expect_error(
+    process_single_season("2025", "2024"),
+    "Season 2024 not finished, no season transition possible."
+  )
+})
+
+context("Team Data Carryover Module")
+
+test_that("load_previous_team_list loads valid team data", {
+  # Create temporary test file
+  test_dir <- tempdir()
+  test_file <- file.path(test_dir, "RCode", "TeamList_2024.csv")
+  dir.create(file.path(test_dir, "RCode"), recursive = TRUE, showWarnings = FALSE)
+  
+  # Write test data
+  test_data <- data.frame(
+    TeamID = c(168, 167),
+    ShortText = c("B04", "HOF"),
+    Promotion = c(0, 0),
+    InitialELO = c(1765, 1628)
+  )
+  write.table(test_data, test_file, sep = ";", row.names = FALSE, quote = FALSE)
+  
+  # Mock file path
+  stub(load_previous_team_list, "paste0", function(...) test_file)
+  stub(load_previous_team_list, "safe_file_read", function(path, ...) test_data)
+  
+  # Test
+  result <- load_previous_team_list("2024")
+  
+  # Assertions
+  expect_equal(nrow(result), 2)
+  expect_equal(result$ShortText[1], "B04")
+  
+  # Cleanup
+  unlink(file.path(test_dir, "RCode"), recursive = TRUE)
+})
+
+test_that("get_existing_team_data returns correct team info", {
+  # Setup
+  prev_data <- data.frame(
+    TeamID = c(168, 167),
+    ShortText = c("B04", "HOF"),
+    Promotion = c(0, -50),
+    stringsAsFactors = FALSE
+  )
+  
+  # Test existing team
+  result <- get_existing_team_data(168, prev_data)
+  expect_equal(result$short_name, "B04")
+  expect_equal(result$promotion_value, 0)
+  
+  # Test second team
+  result <- get_existing_team_data(167, prev_data)
+  expect_equal(result$short_name, "HOF")
+  expect_equal(result$promotion_value, -50)
+  
+  # Test non-existing team
+  result <- get_existing_team_data(999, prev_data)
+  expect_null(result)
+})
+
+test_that("validate_short_name_uniqueness detects duplicates", {
+  # Test with duplicates
+  short_names <- c("B04", "HOF", "B04", "BVB")
+  result <- validate_short_name_uniqueness(short_names)
+  
+  expect_false(result$valid)
+  expect_true("B04" %in% result$duplicates)
+  expect_equal(length(result$duplicates), 1)
+  
+  # Test without duplicates
+  short_names <- c("B04", "HOF", "BVB", "FCB")
+  result <- validate_short_name_uniqueness(short_names)
+  
+  expect_true(result$valid)
+})
+
+test_that("ensure_unique_short_names fixes duplicates", {
+  # Setup teams with duplicate short names
+  teams <- list(
+    list(id = 168, short_name = "B04"),
+    list(id = 167, short_name = "B04"),  # Duplicate
+    list(id = 165, short_name = "BVB")
+  )
+  
+  # Test
+  result <- ensure_unique_short_names(teams)
+  
+  # Extract short names
+  short_names <- sapply(result, function(t) t$short_name)
+  
+  # Assertions
+  expect_equal(short_names[1], "B04")  # First keeps original
+  expect_match(short_names[2], "B0[0-9]")  # Second gets modified
+  expect_equal(short_names[3], "BVB")  # Unaffected
+  expect_equal(length(unique(short_names)), 3)  # All unique
+})

--- a/tests/testthat/test-season-validation.R
+++ b/tests/testthat/test-season-validation.R
@@ -1,0 +1,223 @@
+# Test suite for season validation functionality
+
+library(testthat)
+library(mockery)
+
+# Source required files
+source("../../RCode/season_validation.R")
+
+context("Season Validation")
+
+test_that("validate_season_completion throws error for incomplete season", {
+  # Mock API to return season with unplayed matches
+  mock_response <- list(
+    response = list(
+      list(fixture = list(status = list(short = "FT"))),  # Finished
+      list(fixture = list(status = list(short = "NS"))),  # Not Started
+      list(fixture = list(status = list(short = "PST")))  # Postponed
+    )
+  )
+  
+  # Mock httr::GET and httr::content
+  stub(validate_season_completion, "httr::GET", function(...) {
+    structure(list(), class = "response")
+  })
+  stub(validate_season_completion, "httr::status_code", 200)
+  stub(validate_season_completion, "httr::content", mock_response)
+  
+  expect_error(
+    validate_season_completion(2024),
+    "Season 2024 not finished, no season transition possible."
+  )
+})
+
+test_that("validate_season_completion passes for completed season", {
+  # All matches finished
+  mock_response <- list(
+    response = list(
+      list(fixture = list(status = list(short = "FT"))),
+      list(fixture = list(status = list(short = "FT"))),
+      list(fixture = list(status = list(short = "AET"))),  # After Extra Time
+      list(fixture = list(status = list(short = "PEN")))   # After Penalties
+    )
+  )
+  
+  # Mock httr functions
+  stub(validate_season_completion, "httr::GET", function(...) {
+    structure(list(), class = "response")
+  })
+  stub(validate_season_completion, "httr::status_code", 200)
+  stub(validate_season_completion, "httr::content", mock_response)
+  
+  expect_true(validate_season_completion(2024))
+})
+
+test_that("validate_season_completion handles API failures gracefully", {
+  # Mock API failure
+  stub(validate_season_completion, "httr::GET", function(...) {
+    structure(list(), class = "response")
+  })
+  stub(validate_season_completion, "httr::status_code", 500)
+  
+  # Should return FALSE on API failure
+  expect_false(validate_season_completion(2024))
+})
+
+test_that("validate_season_completion handles empty response", {
+  # Mock empty response
+  mock_response <- list(response = NULL)
+  
+  stub(validate_season_completion, "httr::GET", function(...) {
+    structure(list(), class = "response")
+  })
+  stub(validate_season_completion, "httr::status_code", 200)
+  stub(validate_season_completion, "httr::content", mock_response)
+  
+  # Should handle gracefully
+  expect_false(validate_season_completion(2024))
+})
+
+context("Season Range Validation")
+
+test_that("validate_season_range validates year format", {
+  # Invalid year format
+  expect_error(
+    validate_season_range("20XX", "2025"),
+    "Seasons must be valid 4-digit years"
+  )
+  
+  expect_error(
+    validate_season_range("2024", "20YY"),
+    "Seasons must be valid 4-digit years"
+  )
+})
+
+test_that("validate_season_range enforces reasonable year bounds", {
+  # Too early
+  expect_error(
+    validate_season_range("1999", "2024"),
+    "Source season must be between 2000 and 2030"
+  )
+  
+  # Too late
+  expect_error(
+    validate_season_range("2024", "2031"),
+    "Target season must be between 2000 and 2030"
+  )
+})
+
+test_that("validate_season_range enforces logical progression", {
+  # Target before source
+  expect_error(
+    validate_season_range("2025", "2024"),
+    "Target season must be after source season"
+  )
+  
+  # Same year
+  expect_error(
+    validate_season_range("2024", "2024"),
+    "Target season must be after source season"
+  )
+})
+
+test_that("validate_season_range limits range size", {
+  # Too large range
+  expect_error(
+    validate_season_range("2010", "2025"),
+    "Season range too large. Maximum 10 seasons supported."
+  )
+})
+
+test_that("validate_season_range checks source season completion", {
+  # Mock incomplete season
+  stub(validate_season_range, "validate_season_completion", FALSE)
+  
+  expect_error(
+    validate_season_range("2024", "2025"),
+    "Source season 2024 is not complete or data not available"
+  )
+})
+
+test_that("validate_season_range warns about existing files", {
+  # Mock file existence
+  stub(validate_season_range, "file.exists", function(path) {
+    grepl("TeamList_2025.csv", path)
+  })
+  
+  # Mock season completion
+  stub(validate_season_range, "validate_season_completion", TRUE)
+  
+  # Should warn but not error
+  expect_warning(
+    result <- validate_season_range("2024", "2025"),
+    "files already exist and will be overwritten"
+  )
+  
+  expect_true(result)
+})
+
+context("API Access Validation")
+
+test_that("validate_api_access checks for API key", {
+  # Mock missing API key
+  stub(validate_api_access, "Sys.getenv", function(key) {
+    if (key == "RAPIDAPI_KEY") return("")
+    return(NULL)
+  })
+  
+  expect_error(
+    validate_api_access(),
+    "RAPIDAPI_KEY environment variable not set"
+  )
+})
+
+test_that("validate_api_access tests API connectivity", {
+  # Mock successful API response
+  stub(validate_api_access, "Sys.getenv", "test-api-key")
+  stub(validate_api_access, "httr::GET", function(...) {
+    structure(list(), class = "response")
+  })
+  stub(validate_api_access, "httr::status_code", 200)
+  
+  expect_true(validate_api_access())
+})
+
+test_that("validate_api_access handles API errors", {
+  # Mock API error
+  stub(validate_api_access, "Sys.getenv", "test-api-key")
+  stub(validate_api_access, "httr::GET", function(...) {
+    structure(list(), class = "response")
+  })
+  stub(validate_api_access, "httr::status_code", 403)
+  
+  expect_false(validate_api_access())
+})
+
+context("Helper Functions")
+
+test_that("get_seasons_to_process returns correct range", {
+  result <- get_seasons_to_process("2020", "2024")
+  expect_equal(result, c(2021, 2022, 2023, 2024))
+  
+  result <- get_seasons_to_process("2023", "2024")
+  expect_equal(result, c(2024))
+  
+  # Adjacent years
+  result <- get_seasons_to_process("2023", "2025")
+  expect_equal(result, c(2024, 2025))
+})
+
+test_that("check_existing_files identifies existing files", {
+  # Mock file existence
+  stub(check_existing_files, "file.exists", function(path) {
+    grepl("TeamList_2024.csv", path)
+  })
+  
+  # Should find existing file
+  result <- check_existing_files("2024")
+  expect_equal(result, "RCode/TeamList_2024.csv")
+  
+  # Should return NULL for non-existing
+  result <- check_existing_files("2025")
+  expect_null(result)
+})


### PR DESCRIPTION
## Summary

This PR fixes critical bugs in the season transition script that prevented proper team data carryover between seasons. Teams now retain their short names and receive correctly calculated ELO ratings.

Fixes #23

## Changes Made

### 1. Team Data Carryover Module
- Created `RCode/team_data_carryover.R` with functions to:
  - Load previous season's TeamList file
  - Match teams by ID and retrieve their ShortText and Promotion values
  - Ensure unique short names across all teams
- Updated `season_processor.R` to use carryover data for existing teams

### 2. ELO Rating Fixes
- Existing teams now receive their **dynamically calculated final ELO ratings** from the previous season
- Fixed issue where teams were incorrectly getting default 1046 or initial values
- The system properly calculates end-of-season ELOs and applies them

### 3. Liga3 Baseline Parameter
- Fixed the function call chain to properly pass Liga3 relegation baseline
- New Liga3 teams now receive the average ELO of relegated teams (not hardcoded 1046)
- Updated: `prompt_for_team_info()`, `get_initial_elo_interactive()`

### 4. Season Completion Validation
- Enhanced validation to check all matches are finished before transition
- Throws error: "Season XXXX not finished, no season transition possible."
- Prevents data corruption from incomplete seasons

### 5. Test Coverage
- Added `test-season-processor.R`: Tests for team carryover and ELO usage
- Updated `test-interactive-prompts.R`: Tests for baseline parameter passing
- Added `test-season-validation.R`: Tests for season completion checks

## Test Results

- ✅ All core functionality implemented and tested
- ✅ Critical linting issues fixed (missing imports, file formatting)
- ⚠️ 222 minor linting issues remain (mostly style-related)

## Files Changed

- **RCode/season_processor.R** - Core fixes for carryover logic
- **RCode/interactive_prompts.R** - Baseline parameter support
- **RCode/season_validation.R** - Enhanced completion checking
- **RCode/team_data_carryover.R** - New module for data carryover
- **run_linting.R** - Updated to include new module
- **tests/testthat/test-*.R** - Comprehensive test coverage

## Example Impact

Before:
```
Team ID: 168 (Bayer Leverkusen)
ShortText: BA1  # Wrong\!
InitialELO: 1046  # Default instead of calculated
```

After:
```
Team ID: 168 (Bayer Leverkusen)
ShortText: B04  # Carried over correctly
InitialELO: 1823  # Calculated final ELO from previous season
```

## Testing Instructions

1. Run season transition: `Rscript scripts/season_transition.R 2024 2025`
2. Verify existing teams keep their ShortText
3. Verify ELO ratings are updated based on match results
4. Try with incomplete season to verify validation works

🤖 Generated with [Claude Code](https://claude.ai/code)