### PR TITLE
Retire C++ engine fallback in production loop — Phase 1 (issue #77)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,11 +98,6 @@ RUN mkdir -p /app/RCode /app/ShinyApp/data
 COPY RCode/ ./RCode/
 COPY ShinyApp/ ./ShinyApp/
 
-# Compile C++ code (fallback when Rust unavailable)
-RUN cd /app/RCode && \
-    R -e "Rcpp::sourceCpp('SpielNichtSimulieren.cpp')" || \
-    echo "Warning: C++ compilation failed, will rely on Rust engine"
-
 # Copy robust startup script
 COPY docker-start.sh /app/start.sh
 RUN chmod +x /app/start.sh

--- a/RCode/rust_integration.R
+++ b/RCode/rust_integration.R
@@ -147,14 +147,10 @@ leagueSimulatorRust <- function(season, n = 10000,
                                adjGoalsAgainst = rep_len(0, numberTeams),
                                adjGoalDiff = rep_len(0, numberTeams)) {
   
-  # Check Rust connection
-  if (!connect_rust_simulator()) {
-    message("Falling back to C++ implementation...")
-    return(leagueSimulatorCPP(season, n, modFactor, homeAdvantage,
-                              numberTeams, adjPoints, adjGoals,
-                              adjGoalsAgainst, adjGoalDiff))
-  }
-  
+  # Caller (update_all_leagues_loop) has already asserted Rust availability.
+  # Per-call connection checks were removed in issue #77 Phase 1; a Rust API
+  # call failure surfaces via stop() in simulate_league_rust() below.
+
   # Convert tibble to data.frame if needed (transform_data returns tibble)
   if ("tbl_df" %in% class(season)) {
     season <- as.data.frame(season)

--- a/RCode/updateScheduler.R
+++ b/RCode/updateScheduler.R
@@ -148,28 +148,30 @@ main <- function() {
   message(sprintf("Rust API: %s", RUST_API_URL))
   message("")
   
-  # Test Rust connection
+  # Assert Rust availability at scheduler startup. Issue #77 Phase 1: there is
+  # no in-process fallback to C++. A missing Rust server fails the scheduler
+  # here so the operator sees the real cause; the loop's own assertion is the
+  # second-tier guard against the server dying mid-run.
   source("RCode/rust_integration.R")
-  rust_available <- connect_rust_simulator()
-  
-  if (!rust_available) {
-    message("WARNING: Rust engine not available, will use C++ fallback")
-    message("Performance will be significantly reduced")
+  if (!connect_rust_simulator()) {
+    stop(sprintf(
+      "Rust simulator not available at %s. Start the Rust server before invoking this scheduler.",
+      RUST_API_URL
+    ))
   }
-  
+
   # Calculate optimal number of loops
   loop_config <- calculate_loops()
-  
-  # Run the update loop with Rust engine
+
+  # Run the update loop. Rust availability has already been asserted above.
   update_all_leagues_loop(
     duration = loop_config$duration,  # Use actual time remaining, not DURATION
     loops = loop_config$loops,
     initial_wait = loop_config$initial_wait,
-    n = 10000,  # Can handle more iterations with Rust
+    n = 10000,
     saison = SEASON,
     TeamList_file = team_list_file,
-    shiny_directory = "ShinyApp",
-    use_rust = rust_available
+    shiny_directory = "ShinyApp"
   )
   
   message("Scheduler completed successfully")

--- a/RCode/update_all_leagues_loop.R
+++ b/RCode/update_all_leagues_loop.R
@@ -1,11 +1,10 @@
-# Complete rerun of model using high-performance Rust engine
-# Provides 50-100x performance improvement over C++ implementation
+# Production simulation loop. Calls the Rust REST API exclusively
+# (issue #77 Phase 1: no in-process C++ fallback).
 
 update_all_leagues_loop <- function(duration = 480, loops = 31, initial_wait = 0,
-                                         n = 10000, saison = "2023", 
-                                         TeamList_file = "RCode/TeamList_2023.csv",
-                                         shiny_directory = "/Users/christophschwerdtfeger/Library/CloudStorage/Dropbox-CSDataScience/Christoph Schwerdtfeger/Coding Projects/LeagueSimulator_Claude/League-Simulator-Update/ShinyApp",
-                                         use_rust = TRUE) {
+                                    n = 10000, saison = "2023",
+                                    TeamList_file = "RCode/TeamList_2023.csv",
+                                    shiny_directory = "/Users/christophschwerdtfeger/Library/CloudStorage/Dropbox-CSDataScience/Christoph Schwerdtfeger/Coding Projects/LeagueSimulator_Claude/League-Simulator-Update/ShinyApp") {
 
   if (loops > 1) {
     waittime <- duration * 60 / (loops - 1) # time between loops
@@ -22,26 +21,17 @@ update_all_leagues_loop <- function(duration = 480, loops = 31, initial_wait = 0
   if (!exists("FT_BL2")) {FT_BL2 <- 0}
   if (!exists("FT_Liga3")) {FT_Liga3 <- 0}
 
-  # Source R Code
-  if (use_rust) {
-    message("=== Using high-performance Rust simulation engine ===")
-    source("RCode/rust_integration.R")
-    
-    # Check Rust connection
-    if (!connect_rust_simulator()) {
-      message("WARNING: Rust simulator not available, falling back to C++ implementation")
-      use_rust <- FALSE
-    }
-  }
-  
-  # Source traditional C++ implementation as fallback
-  if (!use_rust) {
-    message("=== Using traditional C++ simulation engine ===")
-    Rcpp::sourceCpp("RCode/SpielNichtSimulieren.cpp")
-    source("RCode/leagueSimulatorCPP.R")
-    source("RCode/SaisonSimulierenCPP.R")
-    source("RCode/simulationsCPP.R")
-    source("RCode/SpielCPP.R")
+  # Source the Rust REST client and assert the server is reachable before doing
+  # any work. Phase 1 of issue #77: the production loop now requires Rust;
+  # there is no in-process fallback to C++. A missing/broken Rust server fails
+  # the scheduler at startup so the operator sees the real problem instead of
+  # silent engine substitution.
+  source("RCode/rust_integration.R")
+  if (!connect_rust_simulator()) {
+    stop(sprintf(
+      "Rust simulator not available at %s. Check that the Rust server is running before starting the scheduler.",
+      Sys.getenv("RUST_API_URL", "http://localhost:8080")
+    ))
   }
   
   # Common R functions needed regardless of engine
@@ -100,34 +90,31 @@ update_all_leagues_loop <- function(duration = 480, loops = 31, initial_wait = 0
       }
     }
     
-    # Run the models using appropriate engine
-    simulator_function <- if (use_rust) leagueSimulatorRust else leagueSimulatorCPP
-    
     # On first iteration (i == 1), always run all simulations to ensure objects exist
     if (FT_BL != FT_BL_new || i == 1) {
-      message(sprintf("Loop %d: Simulating Bundesliga with %d simulations (%s engine)", 
-                      i, n, if (use_rust) "Rust" else "C++"))
-      Ergebnis <- simulator_function(BL, n = n)
+      message(sprintf("Loop %d: Simulating Bundesliga with %d simulations (Rust engine)",
+                      i, n))
+      Ergebnis <- leagueSimulatorRust(BL, n = n)
       FT_BL <- FT_BL_new
       simulation_executed <- TRUE
     }
     
     if (FT_BL2 != FT_BL2_new || i == 1) {
-      message(sprintf("Loop %d: Simulating 2. Bundesliga with %d simulations (%s engine)", 
-                      i, n, if (use_rust) "Rust" else "C++"))
-      Ergebnis2 <- simulator_function(BL2, n = n)
+      message(sprintf("Loop %d: Simulating 2. Bundesliga with %d simulations (Rust engine)",
+                      i, n))
+      Ergebnis2 <- leagueSimulatorRust(BL2, n = n)
       FT_BL2 <- FT_BL2_new
       simulation_executed <- TRUE
     }
     
     if (FT_Liga3 != FT_Liga3_new || i == 1) {
-      message(sprintf("Loop %d: Simulating 3. Liga with %d simulations (%s engine)", 
-                      i, n, if (use_rust) "Rust" else "C++"))
-      Ergebnis3 <- simulator_function(Liga3, n = n)
+      message(sprintf("Loop %d: Simulating 3. Liga with %d simulations (Rust engine)",
+                      i, n))
+      Ergebnis3 <- leagueSimulatorRust(Liga3, n = n)
       FT_Liga3 <- FT_Liga3_new
       
       # calculate promotion table
-      Ergebnis3_Aufstieg <- simulator_function(Liga3, n = n, adjPoints = adjPoints_Liga3_Aufstieg)
+      Ergebnis3_Aufstieg <- leagueSimulatorRust(Liga3, n = n, adjPoints = adjPoints_Liga3_Aufstieg)
       simulation_executed <- TRUE
     }
     
@@ -147,7 +134,4 @@ update_all_leagues_loop <- function(duration = 480, loops = 31, initial_wait = 0
   }
   
   message(sprintf("\n=== Completed all %d loops at %s ===", loops, format(Sys.time(), "%Y-%m-%d %H:%M:%S")))
-  if (use_rust) {
-    message("Performance boost achieved with Rust engine!")
-  }
 }

--- a/tests/testthat/fixtures/rust-required/TeamList_minimal.csv
+++ b/tests/testthat/fixtures/rust-required/TeamList_minimal.csv
@@ -1,0 +1,5 @@
+TeamID;ShortName;Promotion;InitialELO
+1;TST;0;1500
+2;UAA;0;1500
+3;UBB;0;1500
+4;UCC;0;1500

--- a/tests/testthat/test-rust-required.R
+++ b/tests/testthat/test-rust-required.R
@@ -1,0 +1,105 @@
+# Phase 1 regression net for the Rust-required production loop.
+# Issue #77 / docs/superpowers/plans/2026-05-02-simulation-engine-seam.md.
+
+library(testthat)
+
+# --- Helpers: start/stop the Rust API server in the background ---
+
+rust_binary <- function() {
+  bin <- file.path("..", "..", "league-simulator-rust", "target", "release", "league-simulator-rust")
+  if (!file.exists(bin)) {
+    skip(sprintf("Rust binary not built at %s; run `cargo build --release` in league-simulator-rust/", bin))
+  }
+  normalizePath(bin)
+}
+
+start_rust_server <- function(port = 18080L) {
+  bin <- rust_binary()
+  log <- tempfile(fileext = ".log")
+  pid <- sys::exec_background(bin, args = "--api", std_out = log, std_err = log,
+                              env = c(PORT = as.character(port)))
+  Sys.setenv(RUST_API_URL = sprintf("http://localhost:%d", port))
+  # Wait up to 10 s for the server to become healthy.
+  ok <- FALSE
+  for (i in 1:50) {
+    Sys.sleep(0.2)
+    res <- tryCatch(httr::GET(paste0(Sys.getenv("RUST_API_URL"), "/health"),
+                              httr::timeout(0.5)),
+                    error = function(e) NULL)
+    if (!is.null(res) && httr::status_code(res) == 200) { ok <- TRUE; break }
+  }
+  list(pid = pid, log = log, ok = ok, port = port)
+}
+
+stop_rust_server <- function(handle) {
+  if (!is.null(handle$pid)) {
+    try(tools::pskill(handle$pid), silent = TRUE)
+  }
+}
+
+# Source the production loop fresh so the test sees the current state of the code.
+# The loop's source() calls inside its body assume cwd = repo root; we set it explicitly.
+with_repo_root <- function(expr) {
+  old <- getwd()
+  on.exit(setwd(old), add = TRUE)
+  setwd(file.path(old, "..", ".."))   # tests/testthat -> repo root
+  force(expr)
+}
+
+# --- Tests ---
+
+context("Phase 1 — Rust required, no fallback")
+
+test_that("update_all_leagues_loop runs one iteration end-to-end with Rust up", {
+  skip_if_not_installed("sys")
+  skip_if_not_installed("httr")
+  skip_if_not_installed("jsonlite")
+
+  handle <- start_rust_server()
+  on.exit(stop_rust_server(handle), add = TRUE)
+  if (!handle$ok) {
+    skip(sprintf("Rust server failed to come up on port %d; log: %s",
+                 handle$port, handle$log))
+  }
+
+  # Pre-set the FT counters so the loop's "first iteration" branch runs cleanly.
+  FT_BL <- 0; FT_BL2 <- 0; FT_Liga3 <- 0
+
+  with_repo_root({
+    source("RCode/update_all_leagues_loop.R", local = FALSE)
+    # The function exists post-source; just assert it can be invoked with a
+    # one-loop call and that we don't get an immediate error from sourcing/wiring.
+    # We don't assert on Ergebnis values here — we'd need a stubbed retrieveResults
+    # to do that, and that's a bigger fixture than this test should own. The
+    # post-refactor version of this test (Task 7) will exercise the seam shape.
+    expect_true(exists("update_all_leagues_loop"))
+    # Function signature check: in Phase 1's pre-state, has `use_rust` parameter;
+    # in Phase 1's post-state, does not. We assert nothing here — Task 7 does the
+    # signature check after the refactor.
+  })
+})
+
+test_that("loop fails fast with RUST_API_URL message when Rust is down (post-refactor)", {
+  skip_if_not_installed("httr")
+
+  # Point at a port that is guaranteed to refuse connections (no server here).
+  Sys.setenv(RUST_API_URL = "http://127.0.0.1:1")
+
+  with_repo_root({
+    source("RCode/update_all_leagues_loop.R", local = FALSE)
+    # PRE-REFACTOR EXPECTATION (will FAIL today, by design — this is the canary
+    # the refactor is meant to flip):
+    err <- tryCatch(
+      update_all_leagues_loop(duration = 0, loops = 1, n = 10,
+                              saison = "2024",
+                              TeamList_file = "tests/testthat/fixtures/rust-required/TeamList_minimal.csv",
+                              shiny_directory = tempdir()),
+      error = function(e) e
+    )
+    # Post-refactor: error message must mention RUST_API_URL.
+    # Pre-refactor: today's code logs a warning and silently sources C++ (no error).
+    # So this assertion intentionally fails until Tasks 3–5 land.
+    expect_s3_class(err, "error")
+    expect_match(conditionMessage(err), "RUST_API_URL", fixed = TRUE)
+  })
+})

--- a/tests/testthat/test-rust-required.R
+++ b/tests/testthat/test-rust-required.R
@@ -22,6 +22,8 @@ start_rust_server <- function(port = 18080L) {
   Sys.setenv(PORT = as.character(port))
   pid <- sys::exec_background(bin, args = "--api", std_out = log, std_err = log)
   if (is.na(old_port)) Sys.unsetenv("PORT") else Sys.setenv(PORT = old_port)
+  # Save the prior RUST_API_URL so stop_rust_server can restore it.
+  prior_rust_api_url <- Sys.getenv("RUST_API_URL", unset = NA)
   Sys.setenv(RUST_API_URL = sprintf("http://localhost:%d", port))
   # Wait up to 10 s for the server to become healthy.
   ok <- FALSE
@@ -32,12 +34,20 @@ start_rust_server <- function(port = 18080L) {
                     error = function(e) NULL)
     if (!is.null(res) && httr::status_code(res) == 200) { ok <- TRUE; break }
   }
-  list(pid = pid, log = log, ok = ok, port = port)
+  list(pid = pid, log = log, ok = ok, port = port,
+       prior_rust_api_url = prior_rust_api_url)
 }
 
 stop_rust_server <- function(handle) {
   if (!is.null(handle$pid)) {
     try(tools::pskill(handle$pid), silent = TRUE)
+  }
+  if (!is.null(handle$prior_rust_api_url)) {
+    if (is.na(handle$prior_rust_api_url)) {
+      Sys.unsetenv("RUST_API_URL")
+    } else {
+      Sys.setenv(RUST_API_URL = handle$prior_rust_api_url)
+    }
   }
 }
 
@@ -87,7 +97,15 @@ test_that("loop fails fast with RUST_API_URL message when Rust is down (post-ref
   skip_if_not_installed("httr")
 
   # Point at a port that is guaranteed to refuse connections (no server here).
+  prior_rust_api_url <- Sys.getenv("RUST_API_URL", unset = NA)
   Sys.setenv(RUST_API_URL = "http://127.0.0.1:1")
+  on.exit({
+    if (is.na(prior_rust_api_url)) {
+      Sys.unsetenv("RUST_API_URL")
+    } else {
+      Sys.setenv(RUST_API_URL = prior_rust_api_url)
+    }
+  }, add = TRUE)
 
   with_repo_root({
     source("RCode/update_all_leagues_loop.R", local = FALSE)

--- a/tests/testthat/test-rust-required.R
+++ b/tests/testthat/test-rust-required.R
@@ -16,8 +16,12 @@ rust_binary <- function() {
 start_rust_server <- function(port = 18080L) {
   bin <- rust_binary()
   log <- tempfile(fileext = ".log")
-  pid <- sys::exec_background(bin, args = "--api", std_out = log, std_err = log,
-                              env = c(PORT = as.character(port)))
+  # Pass PORT via the parent environment (sys::exec_background inherits env from
+  # the caller and has no env= parameter as of sys 3.4.3).
+  old_port <- Sys.getenv("PORT", unset = NA)
+  Sys.setenv(PORT = as.character(port))
+  pid <- sys::exec_background(bin, args = "--api", std_out = log, std_err = log)
+  if (is.na(old_port)) Sys.unsetenv("PORT") else Sys.setenv(PORT = old_port)
   Sys.setenv(RUST_API_URL = sprintf("http://localhost:%d", port))
   # Wait up to 10 s for the server to become healthy.
   ok <- FALSE

--- a/tests/testthat/test-rust-required.R
+++ b/tests/testthat/test-rust-required.R
@@ -100,10 +100,12 @@ test_that("loop fails fast with RUST_API_URL message when Rust is down (post-ref
                               shiny_directory = tempdir()),
       error = function(e) e
     )
-    # Post-refactor: error message must mention RUST_API_URL.
+    # Post-refactor: error message must mention "Rust simulator not available"
+    # and include the unreachable URL the test pointed at (http://127.0.0.1:1).
     # Pre-refactor: today's code logs a warning and silently sources C++ (no error).
     # So this assertion intentionally fails until Tasks 3–5 land.
     expect_s3_class(err, "error")
-    expect_match(conditionMessage(err), "RUST_API_URL", fixed = TRUE)
+    expect_match(conditionMessage(err), "Rust simulator not available", fixed = TRUE)
+    expect_match(conditionMessage(err), "127.0.0.1:1", fixed = TRUE)
   })
 })


### PR DESCRIPTION
## Summary

Closes #77 (Phase 1 only — Phase 2 deferred per the PRD's Suggested Phasing).

The production simulation loop now calls \`leagueSimulatorRust()\` exclusively. Missing or broken Rust server fails the scheduler at startup with a \`stop()\` referencing the actual URL, instead of silently substituting C++ results. The brittle runtime \`Rcpp::sourceCpp\` build step in the Dockerfile is gone (the only consumer was the deleted fallback).

- **Loop** (\`RCode/update_all_leagues_loop.R\`): dropped \`use_rust\` parameter; replaced 20-line \`if (use_rust) {...} if (!use_rust) {...}\` block with single \`source(rust_integration.R)\` + \`stop()\` assertion; inlined \`simulator_function\`; simplified iteration messages.
- **Per-call seam** (\`RCode/rust_integration.R\`): removed lines 150–156 (the redundant per-call \`connect_rust_simulator()\` check + \`leagueSimulatorCPP\` fallback inside \`leagueSimulatorRust()\`).
- **Scheduler** (\`RCode/updateScheduler.R\`): warning at lines 155–158 became \`stop()\` referencing \`RUST_API_URL\`; dropped \`use_rust = rust_available\` argument.
- **Dockerfile**: removed lines 101–104 (the \`R -e Rcpp::sourceCpp(...)\` build step). Layer count: 34 → 33.
- **Tests** (\`tests/testthat/test-rust-required.R\` + fixture): TDD regression net with positive (Rust up → loop sources cleanly) and negative (Rust down → expect \`stop()\` with the URL) cases. Uses \`sys::exec_background\` to launch the Rust binary as a subprocess; PORT and RUST_API_URL pass through save/restore env helpers (\`sys::exec_background\` v3.4 has no \`env=\` parameter).

**Phase 1 explicitly preserves the C++ engine** (\`leagueSimulatorCPP.R\`, \`SpielCPP.R\`, \`SpielNichtSimulieren.cpp\`, etc.) because \`scripts/season_transition.R:65\` sources \`SpielCPP.R\`. Phase 2 (a separate, future plan) decides their long-term fate after observing whether season-transition genuinely calls into them or just sources them vestigially.

Net change: 6 files, +179 / −68 lines across 7 commits.

## Test Plan

Verified at every relevant commit and in the final acceptance pass:

- [x] \`tests/testthat/test-rust-required.R\` — both tests GREEN (positive PASS, negative PASS — the new \`stop()\` fires with the URL message).
- [x] Source-code-scoped legacy-fallback grep on production seam files (\`update_all_leagues_loop.R\`, \`rust_integration.R\`, \`updateScheduler.R\`, \`Dockerfile\`) returns only 2 known passive doc-comment refs (lines 128 + 209 in \`rust_integration.R\`, intentionally retained).
- [x] All 7 C++ survivors still present in \`RCode/\`.
- [x] \`docker build -f Dockerfile -t league-simulator:phase1-post .\` succeeds; layer count 33 (one fewer than the 34-layer pre-Phase-1 baseline).
- [x] Container smoke test: \`✅ Rust server ready on port 8080\` in logs; no Rcpp errors.
- [x] \`docker compose config\` validates cleanly.
- [x] Season-transition smoke check (\`Rscript -e 'tryCatch(source("scripts/season_transition.R"), ...)'\`) is byte-identical to the Task-1 baseline at every deletion task and at the end (\`diff_exit=0\`).

### Known limitations (deferred)

- **Phase 2 — fate of the C++ engine.** Open question: does \`scripts/season_transition.R\` actually use \`SpielCPP.R\`, or does it just source it vestigially? If vestigial, Phase 2 deletes the C++ files, the comparison harnesses (\`compare_rust_cpp.R\`, \`tests/rust/test_rust_vs_cpp_detailed.R\`), and the \`RCode/cpp_wrappers.R\`/\`RCpp\` plumbing. If genuinely needed, Phase 2 either keeps C++ permanently as season-transition's tool or migrates season-transition to the Rust seam.
- **Stale "50-100x" performance framing** in a few file headers (\`rust_integration.R:4\`, \`updateScheduler.R:2\` and \`:127\`). Out-of-scope housekeeping; covered by issue #79 (doc-cleanup follow-up).
- **\`tests/test_rust_integration.R\` and CPP testthat files** still exist; their CI status is the responsibility of issue #76 (CI rebuild).

## Provenance

- **PRD:** \`docs/prds/2026-05-02-simulation-engine-seam.md\`
- **Plan:** \`docs/superpowers/plans/2026-05-02-simulation-engine-seam.md\`
- **Companion (already merged):** PR #80 (deployment surface collapse, issue #78) — recovery tag \`pre-deployment-cleanup-2026-05-02\` on origin