### PR TITLE
chore(#76): point docker-compose.yml at :latest tag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   league-simulator-integrated:
-    image: chrisschwer/league-simulator:integrated-system-deps
+    image: chrisschwer/league-simulator:latest
     container_name: league-simulator-integrated
     environment:
       - RAPIDAPI_KEY=${RAPIDAPI_KEY}


### PR DESCRIPTION
## Summary

One-line follow-up to #89. Bumps `docker-compose.yml`'s image tag from the stale `:integrated-system-deps` to `:latest`. The new tag is now published by `ci.yml` on every green main commit; `:integrated-system-deps` was an artifact name from the pre-cleanup multi-Dockerfile era.

## Risk

Minimal. Operators pulling `:integrated-system-deps` continue to work (old tag stays on Docker Hub). New `docker-compose pull` runs will fetch `:latest` from this point forward.

## Test plan

- [ ] CI runs against this PR (trivially — no functional change to workflow itself; image-build cache hits)
- [ ] After merge: `docker-compose pull` from any host fetches `:latest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
