### PR TITLE
ci(#76): conditional cache-to so Dependabot PRs don't fail on auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,13 +106,18 @@ jobs:
 
       - name: Build production image
         uses: docker/build-push-action@v5
+        env:
+          # Compute cache-to dynamically: empty string disables export.
+          # Dependabot PRs and fork PRs don't get DOCKERHUB_TOKEN, so they
+          # can read the public cache but cannot write back.
+          CACHE_TO: ${{ secrets.DOCKERHUB_TOKEN != '' && format('type=registry,ref={0}:{1},mode=min', env.IMAGE_NAME, env.CACHE_TAG) || '' }}
         with:
           context: .
           file: Dockerfile
           load: true
           tags: ${{ steps.meta.outputs.tag }}
           cache-from: type=registry,ref=${{ env.IMAGE_NAME }}:${{ env.CACHE_TAG }}
-          cache-to: type=registry,ref=${{ env.IMAGE_NAME }}:${{ env.CACHE_TAG }},mode=min
+          cache-to: ${{ env.CACHE_TO }}
 
       - name: Run testthat inside the image
         run: |
@@ -181,6 +186,8 @@ jobs:
       # ~2-3 min when only Rust source changed). Hobbyist project; conscious tradeoff.
       - name: Build and push (cached from previous job)
         uses: docker/build-push-action@v5
+        env:
+          CACHE_TO: ${{ secrets.DOCKERHUB_TOKEN != '' && format('type=registry,ref={0}:{1},mode=min', env.IMAGE_NAME, env.CACHE_TAG) || '' }}
         with:
           context: .
           file: Dockerfile
@@ -189,7 +196,7 @@ jobs:
             ${{ env.IMAGE_NAME }}:latest
             ${{ env.IMAGE_NAME }}:${{ steps.sha.outputs.short }}
           cache-from: type=registry,ref=${{ env.IMAGE_NAME }}:${{ env.CACHE_TAG }}
-          cache-to: type=registry,ref=${{ env.IMAGE_NAME }}:${{ env.CACHE_TAG }},mode=min
+          cache-to: ${{ env.CACHE_TO }}
 
   report-failure:
     name: Open or update CI failure issue


### PR DESCRIPTION
## Summary

Real CI design bug surfaced by Dependabot PRs #91 (rust 1.81→1.95) and #93 (gh-actions group). Both fail \`image-build-and-test\` with:

\`\`\`
failed to fetch oauth token: 401 Unauthorized: access token has insufficient scopes
\`\`\`

The Docker Hub login step is conditional on \`DOCKERHUB_USERNAME != ''\`, but \`cache-to: type=registry,...:cache\` is unconditional. Dependabot PRs don't get repository secrets (GitHub's security model), so the registry cache export fails on auth.

## Fix

Make \`cache-to\` conditional too. When \`DOCKERHUB_TOKEN\` is set, write to registry as before. When empty, omit (BuildKit skips the export). Dependabot PRs continue to benefit from \`cache-from\` (public read).

Same fix applied defensively to \`push-image\` (it always has the token in practice, but explicit conditional is clearer).

## Out of scope

- PR #94 (rust-deps group) which has a real \`rand\` 0.8→0.9 source incompatibility — that needs separate work.

## Test plan

- [ ] CI on this PR is green (regular PR — secrets available, behavior unchanged)
- [ ] After merge: re-rebase Dependabot PRs #91 and #93 and confirm they pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)