### PR TITLE
test(#90): add HTTP-handler unit tests for /health and /simulate

### DIFF
--- a/league-simulator-rust/Cargo.toml
+++ b/league-simulator-rust/Cargo.toml
@@ -37,6 +37,9 @@ criterion = { version = "0.5", features = ["html_reports"] }
 proptest = "1.4"
 assert_approx_eq = "1.1"
 tempfile = "3.8"
+# HTTP-handler tests use `tower::ServiceExt::oneshot` (util feature)
+tower = { version = "0.4", features = ["util"] }
+http-body-util = "0.1"
 
 # Benchmarks disabled for initial build
 # [[bench]]

--- a/league-simulator-rust/src/api/mod.rs
+++ b/league-simulator-rust/src/api/mod.rs
@@ -3,6 +3,9 @@
 
 pub mod handlers;
 
+#[cfg(test)]
+mod tests;
+
 use axum::{
     http::Method,
     routing::{get, post},

--- a/league-simulator-rust/src/api/tests.rs
+++ b/league-simulator-rust/src/api/tests.rs
@@ -1,0 +1,199 @@
+//! HTTP-API handler tests.
+//!
+//! These tests exercise the `axum::Router` returned by `create_router` using
+//! `tower::ServiceExt::oneshot`, so no real port is opened. They pin the
+//! wire-format contract that the R-side scheduler depends on, and they
+//! document the validation paths in `simulate_league` (empty schedule, empty
+//! elo_values).
+
+use crate::api::create_router;
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use http_body_util::BodyExt;
+use serde_json::{json, Value};
+use tower::ServiceExt;
+
+/// Send `req` through the router and return (status, parsed JSON body).
+async fn send(req: Request<Body>) -> (StatusCode, Value) {
+    let response = create_router()
+        .oneshot(req)
+        .await
+        .expect("router service should not fail");
+
+    let status = response.status();
+    let bytes = response
+        .into_body()
+        .collect()
+        .await
+        .expect("body collect")
+        .to_bytes();
+    let body: Value = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes).expect("response body should be valid JSON")
+    };
+
+    (status, body)
+}
+
+fn post_simulate_json(payload: Value) -> Request<Body> {
+    Request::builder()
+        .method("POST")
+        .uri("/simulate")
+        .header("content-type", "application/json")
+        .body(Body::from(serde_json::to_vec(&payload).unwrap()))
+        .unwrap()
+}
+
+/// A minimal valid simulate request: 2 teams, 1 played match plus 1 to
+/// simulate, low iteration count to keep tests fast.
+fn minimal_valid_simulate_payload() -> Value {
+    json!({
+        "schedule": [
+            [1, 2, 1, 0],          // played match
+            [2, 1, null, null]     // match to simulate
+        ],
+        "elo_values": [1500.0, 1500.0],
+        "iterations": 50
+    })
+}
+
+#[tokio::test]
+async fn health_returns_ok_with_status_version_and_performance_fields() {
+    let req = Request::builder()
+        .method("GET")
+        .uri("/health")
+        .body(Body::empty())
+        .unwrap();
+
+    let (status, body) = send(req).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["status"], "ok");
+    assert!(
+        body["version"].is_string(),
+        "version field must be present and a string, got: {body}"
+    );
+    assert!(
+        body["performance"].is_string(),
+        "performance field must be present and a string, got: {body}"
+    );
+}
+
+#[tokio::test]
+async fn simulate_returns_400_when_schedule_is_empty() {
+    let req = post_simulate_json(json!({
+        "schedule": [],
+        "elo_values": [1500.0, 1500.0],
+        "iterations": 10
+    }));
+
+    let (status, _body) = send(req).await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn simulate_returns_400_when_elo_values_is_empty() {
+    let req = post_simulate_json(json!({
+        "schedule": [[1, 2, 1, 0]],
+        "elo_values": [],
+        "iterations": 10
+    }));
+
+    let (status, _body) = send(req).await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn simulate_happy_path_returns_probability_matrix_with_expected_shape() {
+    let req = post_simulate_json(minimal_valid_simulate_payload());
+
+    let (status, body) = send(req).await;
+
+    assert_eq!(status, StatusCode::OK);
+
+    let matrix = body["probability_matrix"]
+        .as_array()
+        .expect("probability_matrix must be a JSON array");
+    assert_eq!(matrix.len(), 2, "matrix should have one row per team");
+    for row in matrix {
+        let cols = row.as_array().expect("each row must be an array");
+        assert_eq!(
+            cols.len(),
+            2,
+            "each row should have one column per position"
+        );
+        let row_sum: f64 = cols.iter().map(|v| v.as_f64().unwrap()).sum();
+        assert!(
+            (row_sum - 1.0).abs() < 1e-9,
+            "row probabilities must sum to 1, got {row_sum}"
+        );
+    }
+
+    let names = body["team_names"]
+        .as_array()
+        .expect("team_names must be a JSON array");
+    assert_eq!(names.len(), 2);
+
+    assert_eq!(
+        body["simulations_performed"].as_u64().unwrap(),
+        50,
+        "simulations_performed should reflect the requested iterations"
+    );
+    assert!(
+        body["time_ms"].is_number(),
+        "time_ms must be a number, got: {body}"
+    );
+}
+
+#[tokio::test]
+async fn simulate_uses_caller_supplied_team_names_in_response() {
+    let mut payload = minimal_valid_simulate_payload();
+    payload["team_names"] = json!(["Foo FC", "Bar United"]);
+
+    let req = post_simulate_json(payload);
+    let (status, body) = send(req).await;
+
+    assert_eq!(status, StatusCode::OK);
+    let names: Vec<String> = body["team_names"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    assert!(
+        names.contains(&"Foo FC".to_string()),
+        "response team_names must contain caller-supplied 'Foo FC', got {names:?}"
+    );
+    assert!(
+        names.contains(&"Bar United".to_string()),
+        "response team_names must contain caller-supplied 'Bar United', got {names:?}"
+    );
+}
+
+#[tokio::test]
+async fn simulate_defaults_iterations_to_10000_when_not_provided() {
+    // Note: this is the slow test (10k iterations) — kept minimal (2 teams,
+    // 2-match schedule) so it still completes well under a second on dev
+    // hardware.
+    let req = post_simulate_json(json!({
+        "schedule": [
+            [1, 2, 1, 0],
+            [2, 1, null, null]
+        ],
+        "elo_values": [1500.0, 1500.0]
+    }));
+
+    let (status, body) = send(req).await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        body["simulations_performed"].as_u64().unwrap(),
+        10_000,
+        "default iterations should be 10000 when caller omits the field"
+    );
+}


### PR DESCRIPTION
## Summary

- Closes #90
- Adds 6 unit tests in `league-simulator-rust/src/api/tests.rs` that exercise the axum `Router` via `tower::ServiceExt::oneshot` — no real port, no real HTTP socket. This is the testing pattern the issue suggested.
- The handler under test (`src/api/handlers.rs`) is **not modified**. This is preventive coverage to make Rust-side refactors safer, exactly the scope the issue asked for.

## Tests added

| Test | What it pins |
|---|---|
| `health_returns_ok_with_status_version_and_performance_fields` | `/health` returns 200 with `status: "ok"` plus string `version` and `performance` fields |
| `simulate_returns_400_when_schedule_is_empty` | First validation branch in `simulate_league` |
| `simulate_returns_400_when_elo_values_is_empty` | Second validation branch in `simulate_league` |
| `simulate_happy_path_returns_probability_matrix_with_expected_shape` | 200 status, matrix is `teams × positions`, each row sums to 1.0, `simulations_performed == requested iterations`, `time_ms` is numeric |
| `simulate_uses_caller_supplied_team_names_in_response` | `team_names` from the request appear in the response (vs. being replaced by auto-generated `Team_N`) |
| `simulate_defaults_iterations_to_10000_when_not_provided` | Default-iterations behavior when the field is omitted |

## Mutation verification (RED-GREEN proof)

Since the handler already exists, I verified each test catches a real regression by making a targeted mutation in `handlers.rs`, watching the test fail, then reverting:

| Mutation | Tests that failed |
|---|---|
| Skip the two `is_empty` validations | `simulate_returns_400_when_schedule_is_empty`, `simulate_returns_400_when_elo_values_is_empty` (both panicked with index OOB without validation — extra evidence the validation matters) |
| `simulations_performed: 9999` | `simulate_happy_path_…` and `simulate_defaults_iterations_…` |
| Always overwrite caller-supplied `team_names` with auto-generated ones | `simulate_uses_caller_supplied_team_names_…` |
| Zero out `probability_matrix` | `simulate_happy_path_…` (row-sum check) |
| `status: \"degraded\"` instead of `\"ok\"` | `health_returns_ok_…` |

Each mutation failed exactly the expected test(s) and nothing else.

## What's *not* in this PR (and why)

- **Mismatched-array-length validation** — the issue mentions it, but the handler currently has no such check. Adding tests for it would mean adding production logic, which is outside the issue's "preventive coverage" scope. Flagged for follow-up if desired.
- **Invalid iteration counts** — likewise; `iterations: Option<usize>` can't be negative, and `0` is syntactically valid. No production validation exists today.
- **Routing-setup tests** — the issue calls these optional. They are implicitly covered by the fact that all tests go through `create_router()`.
- **`tests/api_contract.rs` integration test** — the issue calls it "optional"; the unit tests above cover the contract.

## Test plan

- [x] `cargo test --release --lib api::tests` — 6 passed, 0 failed
- [x] `cargo test --release --lib` — 22 passed, 0 failed, 1 ignored (the pre-existing `test_monte_carlo_deterministic` from #96)
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets --release -- -D warnings` — clean
- [x] `git diff handlers.rs` — empty (no production code change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)