### PR TITLE
build(deps): rand 0.9/0.10, axum 0.8, tower 0.5, criterion 0.8 + API migration

### DIFF
--- a/league-simulator-rust/Cargo.toml
+++ b/league-simulator-rust/Cargo.toml
@@ -9,18 +9,18 @@ description = "High-performance football league Monte Carlo simulator"
 # Core dependencies
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-rand = "0.8"
-rand_distr = "0.4"
+rand = "0.10"
+rand_distr = "0.6"
 rayon = "1.8"
 
 # Web framework for REST API
-axum = "0.7"
+axum = "0.8"
 tokio = { version = "1.35", features = ["full"] }
-tower = "0.4"
-tower-http = { version = "0.5", features = ["cors"] }
+tower = "0.5"
+tower-http = { version = "0.6", features = ["cors"] }
 
 # Numerical computation
-statrs = "0.16"  # Statistical distributions
+statrs = "0.18"  # Statistical distributions
 approx = "0.5"   # Floating point comparisons
 
 # Logging
@@ -28,17 +28,17 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # Error handling
-thiserror = "1.0"
+thiserror = "2.0"
 anyhow = "1.0"
 
 [dev-dependencies]
 # Testing utilities
-criterion = { version = "0.5", features = ["html_reports"] }
+criterion = { version = "0.8", features = ["html_reports"] }
 proptest = "1.4"
 assert_approx_eq = "1.1"
 tempfile = "3.8"
 # HTTP-handler tests use `tower::ServiceExt::oneshot` (util feature)
-tower = { version = "0.4", features = ["util"] }
+tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"
 
 # Benchmarks disabled for initial build

--- a/league-simulator-rust/benches/simulation_bench.rs
+++ b/league-simulator-rust/benches/simulation_bench.rs
@@ -1,5 +1,6 @@
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use league_simulator_rust::*;
+use std::hint::black_box;
 
 fn create_bundesliga_season() -> Season {
     // Create a realistic Bundesliga season (18 teams, 306 matches)

--- a/league-simulator-rust/src/monte_carlo/mod.rs
+++ b/league-simulator-rust/src/monte_carlo/mod.rs
@@ -1,6 +1,6 @@
 use crate::models::{Season, SimulationParams, SimulationResult};
 use crate::simulation::process_season;
-use rand::{rngs::StdRng, thread_rng, Rng, SeedableRng};
+use rand::{rngs::StdRng, RngExt, SeedableRng};
 use rayon::prelude::*;
 use std::sync::Mutex;
 
@@ -16,8 +16,8 @@ pub fn run_monte_carlo_simulation(
     params: &SimulationParams,
     team_names: Vec<String>,
 ) -> SimulationResult {
-    let mut rng = thread_rng();
-    let seeds: Vec<u64> = (0..params.iterations).map(|_| rng.gen()).collect();
+    let mut rng = rand::rng();
+    let seeds: Vec<u64> = (0..params.iterations).map(|_| rng.random()).collect();
     run_monte_carlo_simulation_with_seeds(season, params, team_names, &seeds)
 }
 
@@ -39,7 +39,7 @@ pub fn run_monte_carlo_simulation_seeded(
     master_seed: u64,
 ) -> SimulationResult {
     let mut master = StdRng::seed_from_u64(master_seed);
-    let seeds: Vec<u64> = (0..params.iterations).map(|_| master.gen()).collect();
+    let seeds: Vec<u64> = (0..params.iterations).map(|_| master.random()).collect();
     run_monte_carlo_simulation_with_seeds(season, params, team_names, &seeds)
 }
 

--- a/league-simulator-rust/src/simulation/match_sim.rs
+++ b/league-simulator-rust/src/simulation/match_sim.rs
@@ -38,7 +38,7 @@ pub fn simulate_match(
 }
 
 /// Simulates a match with actual random number generation
-pub fn simulate_match_random<R: rand::Rng>(
+pub fn simulate_match_random<R: rand::Rng + rand::RngExt>(
     elo_home: f64,
     elo_away: f64,
     mod_factor: f64,
@@ -47,8 +47,8 @@ pub fn simulate_match_random<R: rand::Rng>(
     tore_intercept: f64,
     rng: &mut R,
 ) -> EloResult {
-    let random_home = rng.gen::<f64>();
-    let random_away = rng.gen::<f64>();
+    let random_home = rng.random::<f64>();
+    let random_away = rng.random::<f64>();
 
     simulate_match(
         elo_home,

--- a/league-simulator-rust/src/simulation/match_sim_fixed.rs
+++ b/league-simulator-rust/src/simulation/match_sim_fixed.rs
@@ -38,7 +38,7 @@ pub fn simulate_match(
 }
 
 /// Simulates a match with actual random number generation
-pub fn simulate_match_random<R: rand::Rng>(
+pub fn simulate_match_random<R: rand::Rng + rand::RngExt>(
     elo_home: f64,
     elo_away: f64,
     mod_factor: f64,
@@ -47,8 +47,8 @@ pub fn simulate_match_random<R: rand::Rng>(
     tore_intercept: f64,
     rng: &mut R,
 ) -> EloResult {
-    let random_home = rng.gen::<f64>();
-    let random_away = rng.gen::<f64>();
+    let random_home = rng.random::<f64>();
+    let random_away = rng.random::<f64>();
     
     simulate_match(
         elo_home,


### PR DESCRIPTION
## Summary

- Closes #94
- Replaces the auto-generated Dependabot PR #94 with a working version that includes the source-code changes the new dependency versions require.

The Dependabot group bumps the following crates, all of which had API breaks in the bumped versions:

| Crate | From | To | Source impact |
|---|---|---|---|
| rand | 0.8 | 0.10 | `thread_rng()` → `rand::rng()`, `Rng::gen()` → `RngExt::random()` |
| rand_distr | 0.4 | 0.6 | (transitive only, no direct usage) |
| axum | 0.7 | 0.8 | (no source impact in our usage) |
| tower | 0.4 | 0.5 | (no source impact in our usage) |
| tower-http | 0.5 | 0.6 | (no source impact in our usage) |
| statrs | 0.16 | 0.18 | (no source impact in our usage) |
| thiserror | 1.0 | 2.0 | (no source impact in our usage) |
| criterion | 0.5 | 0.8 | `criterion::black_box` deprecated → `std::hint::black_box` |

## Migration details (rand)

- `rand::thread_rng()` → `rand::rng()` (2 call sites in `monte_carlo/mod.rs`)
- `Rng::gen()` / `.gen::<T>()` → `RngExt::random()` / `.random::<T>()` (in `monte_carlo/mod.rs`, `simulation/match_sim.rs`, `simulation/match_sim_fixed.rs`)
- Add `rand::RngExt` to the imports in `monte_carlo/mod.rs` and as a generic bound on `simulate_match_random<R: Rng + RngExt>` in both `match_sim.rs` and `match_sim_fixed.rs`

### Verified against the rand docs

- `random::<f64>()` returns values in `[0, 1)` from `StandardUniform` — same range and distribution as the old `gen::<f64>()`. Match-simulation probability thresholds in `simulate_match` are unaffected.
- `StdRng` is explicitly documented as *not* portable across `rand` versions, so a fixed seed in 0.8 will produce a different output stream in 0.10. Audited the codebase: **no hardcoded reference values depend on `StdRng` output**. The R-parity tests use random values supplied as fixed JSON inputs (not drawn from a Rust RNG), and the only seed-using tests assert structural properties or compare a seeded run to itself.

### `criterion::black_box`

Deprecated in `criterion` 0.6+ in favor of `std::hint::black_box`. One import swap in `benches/simulation_bench.rs`.

## Why a separate PR (not just rebasing #94)

PR #94 was Dependabot's auto-generated bump. As I commented on it, it cannot merge as-is because the version bumps require source-code changes that Dependabot does not generate. This PR carries those changes; #94 should be closed in favor of it.

## Test plan

- [x] `cargo test --release` — 23 lib + 1 integration test pass, 0 fail, 0 ignored
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets --release -- -D warnings` — clean
- [x] Production wire format unchanged (`api/handlers.rs` and `RCode/rust_integration.R` untouched)
- [x] Verified rand 0.10 docs for value-stability claims (`StandardUniform` for `f64` still yields `[0, 1)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)