### PR TITLE
fix: exclude relegation playoff fixtures from league simulation

### DIFF
--- a/RCode/transform_data.R
+++ b/RCode/transform_data.R
@@ -2,9 +2,16 @@ library(dplyr)
 library(tidyr)
 
 transform_data <- function(fixtures, teams) {
-  
+
   temp_ELO <- 0
-  
+
+  # API-Football includes relegation playoff games as round "Final" in the
+  # league fixture list; only regular-season rounds belong in the simulation
+  rounds <- if ("league" %in% names(fixtures)) fixtures$league$round else NULL
+  if (!is.null(rounds)) {
+    fixtures <- fixtures[startsWith(as.character(rounds), "Regular Season"), ]
+  }
+
   fixtures_flat <- fixtures %>% unnest(cols = c("teams", "goals", "fixture"), names_sep = "_")
   fixtures_flat <- fixtures_flat %>% unnest(cols = c("teams_home", "teams_away", "fixture_status"), names_sep = "_")
   fixtures_flat$fixture_status_short <- replace_na(fixtures_flat$fixture_status_short, "NA")
@@ -21,10 +28,11 @@ transform_data <- function(fixtures, teams) {
                                ifelse(df_final$TeamGast == team, df_final$ELOAway, NA))
   }
   
-  # set goals to NA unless game is finished ("FT")
-  
+  # set goals to NA unless game is finished
+  # (FT = full time, AET = after extra time, PEN = decided on penalties)
+
   for (i in 1:dim(df_final)[1]) {
-    if (df_final$fixture_status_short[i] != "FT") {
+    if (!df_final$fixture_status_short[i] %in% c("FT", "AET", "PEN")) {
       df_final$ToreHeim[i] <- NA
       df_final$ToreGast[i] <- NA
     }

--- a/tests/testthat/test-transform_data.R
+++ b/tests/testthat/test-transform_data.R
@@ -182,18 +182,18 @@ test_that("transform_data handles different game statuses", {
   teams <- create_test_teams_api()
   
   result <- transform_data(fixtures, teams)
-  
-  # Only FT games should have results (not AET, PEN, etc. based on the code)
+
+  # FT, AET and PEN all count as finished games
   expect_equal(result$ToreHeim[1], 1)
   expect_equal(result$ToreGast[1], 0)
-  
-  # AET should have NA (not FT)
-  expect_true(is.na(result$ToreHeim[2]))
-  expect_true(is.na(result$ToreGast[2]))
-  
-  # PEN should have NA (not FT)
-  expect_true(is.na(result$ToreHeim[3]))
-  expect_true(is.na(result$ToreGast[3]))
+
+  # AET is finished (decided after extra time)
+  expect_equal(result$ToreHeim[2], 2)
+  expect_equal(result$ToreGast[2], 1)
+
+  # PEN is finished (decided on penalties)
+  expect_equal(result$ToreHeim[3], 1)
+  expect_equal(result$ToreGast[3], 1)
   
   # NS should have NA
   expect_true(is.na(result$ToreHeim[4]))
@@ -266,6 +266,65 @@ test_that("transform_data handles NULL goal values", {
   # NULL should be converted to NA
   expect_true(is.na(result$ToreHeim[1]))
   expect_true(is.na(result$ToreGast[1]))
+})
+
+test_that("transform_data drops non-regular-season rounds (relegation playoff)", {
+  # API-Football delivers the relegation playoff as round "Final" within the
+  # league fixture list (e.g. Bundesliga 16th vs. 2. Bundesliga 3rd). Those
+  # games must not enter the simulation: the lower-league team would appear
+  # as an extra team and the playoff results would distort the table.
+  fixtures <- tibble::tibble(
+    league = data.frame(
+      round = c("Regular Season - 33", "Regular Season - 34", "Final", "Final"),
+      stringsAsFactors = FALSE
+    ),
+    teams = list(
+      data.frame(
+        home = I(list(data.frame(id = 101, name = "Team A"))),
+        away = I(list(data.frame(id = 102, name = "Team B")))
+      ),
+      data.frame(
+        home = I(list(data.frame(id = 103, name = "Team C"))),
+        away = I(list(data.frame(id = 104, name = "Team D")))
+      ),
+      data.frame(  # playoff first leg: league team vs. playoff intruder
+        home = I(list(data.frame(id = 102, name = "Team B"))),
+        away = I(list(data.frame(id = 105, name = "Playoff Team")))
+      ),
+      data.frame(  # playoff second leg, decided after extra time
+        home = I(list(data.frame(id = 105, name = "Playoff Team"))),
+        away = I(list(data.frame(id = 102, name = "Team B")))
+      )
+    ),
+    goals = list(
+      data.frame(home = 2, away = 1),
+      data.frame(home = 1, away = 1),
+      data.frame(home = 0, away = 0),
+      data.frame(home = 2, away = 1)
+    ),
+    fixture = list(
+      data.frame(id = 1001, status = I(list(data.frame(short = "FT")))),
+      data.frame(id = 1002, status = I(list(data.frame(short = "FT")))),
+      data.frame(id = 1003, status = I(list(data.frame(short = "FT")))),
+      data.frame(id = 1004, status = I(list(data.frame(short = "AET"))))
+    )
+  )
+
+  teams <- data.frame(
+    TeamID = c(101, 102, 103, 104, 105),
+    ShortText = c("TEA", "TEB", "TEC", "TED", "PLT"),
+    InitialELO = c(1500, 1450, 1550, 1400, 1430),
+    stringsAsFactors = FALSE
+  )
+
+  result <- transform_data(fixtures, teams)
+
+  # Only the two regular-season games survive
+  expect_equal(nrow(result), 2)
+  expect_equal(result$TeamHeim, c("TEA", "TEC"))
+
+  # The playoff team must not appear as a team column
+  expect_false("PLT" %in% colnames(result))
 })
 
 test_that("transform_data creates proper data structure", {


### PR DESCRIPTION
## Problem

Nach Saisonende zeigte die Bundesliga-Prognose 19 Teams (SC Paderborn als Eindringling) und Restunsicherheit auf den Plätzen 14–16, obwohl alle Spiele beendet sind.

**Ursache:** API-Football liefert die Relegationsspiele als Runde `"Final"` innerhalb der Liga-Fixtures (BL 78: WOB–SCP; BL2 79: SGF–RWE). Der Code filterte nicht nach Runde, daher:

1. Paderborn tauchte als 19. Bundesliga-Team auf (Teamliste wird aus Fixtures abgeleitet)
2. Das Relegations-Hinspiel (0:0, `FT`) zählte als Ligaspiel und verfälschte die Tabelle
3. Das Rückspiel endete nach Verlängerung (Status `AET` ≠ `FT`) und wurde als ungespielt behandelt → in jedem Durchlauf neu simuliert → die 23 %/77 %-Restwahrscheinlichkeiten bei BRE/WOB

Die 2. Bundesliga war analog betroffen (Rot-Weiß Essen als 19. Team), nur unauffälliger, weil beide Playoff-Spiele `FT` waren.

## Fix

- `transform_data` behält nur Fixtures, deren Runde mit `"Regular Season"` beginnt
- `AET` und `PEN` gelten zusätzlich als beendete Spielstatus (Robustheit)

## Verifikation

- TDD: neue Tests erst rot gesehen, dann grün
- Volle Testsuite: 287 PASS, 0 FAIL (Warnungen in interactive-prompts/season-validation vorbestehend)
- End-to-End gegen echte API-Daten (11.06.2026): BL 306 Spiele / 18 Teams / 0 offene Spiele, SCP raus; BL2 18 Teams, RWE raus, SCP korrekt drin; Liga3 unverändert

🤖 Generated with [Claude Code](https://claude.com/claude-code)