### PR TITLE
docs: add .env.example template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# League Simulator environment configuration.
+# Copy to .env and fill in real values:  cp .env.example .env
+# .env is gitignored — never commit real credentials.
+# Full variable reference: docs/deployment/README.md
+
+# --- Required ---
+RAPIDAPI_KEY=your_rapidapi_key_here
+SHINYAPPS_IO_SECRET=your_shinyapps_secret_here
+SHINYAPPS_IO_TOKEN=your_shinyapps_token_here
+
+# --- Optional (defaults shown) ---
+# SHINYAPPS_IO_NAME=chrisschwer
+# SEASON=2025
+# DURATION=480
+# RUST_API_URL=http://localhost:8080
+# TZ=Europe/Berlin

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ All three run in a single Docker container on a Linux server; the scheduler talk
 ## Deploy
 
 ```bash
+cp .env.example .env   # then fill in the required credentials
 docker-compose up -d --build
 ```
 

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -28,6 +28,8 @@ The League Simulator runs as a single Docker container that combines the Rust si
 | `RUST_API_URL` | no | `http://localhost:8080` | Rust server endpoint inside the container |
 | `TZ` | no | `Europe/Berlin` | Container timezone |
 
+A ready-to-copy template with all variables lives at [`.env.example`](../../.env.example): `cp .env.example .env`, then fill in the three required values. `.env` itself is gitignored.
+
 ## Build and run
 
 ```bash

--- a/docs/deployment/quick-start.md
+++ b/docs/deployment/quick-start.md
@@ -16,15 +16,11 @@ Deploy the League Simulator in 5 minutes.
 git clone https://github.com/chrisschwer/League-Simulator-Update.git
 cd League-Simulator-Update
 
-cat > .env <<'EOF'
-RAPIDAPI_KEY=your_rapidapi_key_here
-SHINYAPPS_IO_SECRET=your_shiny_secret_here
-SHINYAPPS_IO_TOKEN=your_shiny_token_here
-# Optional — see deployment/README.md for the full list:
-# SHINYAPPS_IO_NAME=chrisschwer
-# SEASON=2025
-# DURATION=480
-EOF
+cp .env.example .env
+# Then edit .env and fill in the three required values:
+#   RAPIDAPI_KEY, SHINYAPPS_IO_SECRET, SHINYAPPS_IO_TOKEN
+# Optional vars are listed (commented out) in the template — see
+# deployment/README.md for the full reference.
 ```
 
 ## 2. Build and run


### PR DESCRIPTION
## Summary
- Adds a checked-in `.env.example` with dummy values: the three required variables (`RAPIDAPI_KEY`, `SHINYAPPS_IO_SECRET`, `SHINYAPPS_IO_TOKEN`) plus all optional ones commented out with their defaults, matching the table in docs/deployment/README.md
- Quick-start now says `cp .env.example .env` instead of a heredoc; root README and deployment README point to the template
- `.env` remains gitignored (the `.gitignore` pattern `.env` matches only the exact filename, so `.env.example` is tracked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)