### PR TITLE
docs: deployment migration designs, plans, and 2026 review PRDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,9 @@ poisson_test_cases.csv
 show_bl2_results.R
 single_match_test_cases.csv
 test_*.R
+
+# Season-transition backups and operator run artifacts
+backup_season_*.tar.gz
+logs/
+processing_*.log
+testthat-summary.txt

--- a/docs/prds/2026-05-02-deployment-surface-collapse.md
+++ b/docs/prds/2026-05-02-deployment-surface-collapse.md
@@ -1,0 +1,227 @@
+# Collapse deployment surface to one production stack
+
+**Scope:** repository root (Dockerfiles, docker-compose files, `docker/`, `k8s/`, `scripts/` deployment helpers) and `.github/workflows/` (inventory only). **Out of scope but must continue to work:** the season-transition operator workflow (`scripts/season_transition.R` and the 15 `RCode/` modules it depends on, per `docs/SEASON_TRANSITION_UPDATES.md` and issue #74).
+**Date:** 2026-05-02
+**Source:** architecture-review-prd skill
+
+## Goal
+
+The repo contains exactly one production deployment stack — `Dockerfile.integrated` + `docker-compose.integrated.yml` + `docker-integrated-start.sh` + `RCode/updateSchedulerRust.R` — and a new operator README that documents it as the only path. All previous deployment experiments (simple/league/shiny/optimized Dockerfiles, the legacy `DOCKERFILE`, the `k8s/` directory, the unused schedulers) are removed from the working tree. **The season-transition operator workflow continues to work unchanged**: `Rscript scripts/season_transition.R 2024 2025` produces a valid `RCode/TeamList_2025.csv` after the cleanup, and the operator-tool wrappers from issue #74 still resolve their dependencies.
+
+## Architecture
+
+A single Docker image, built from `Dockerfile.integrated`, runs both the Rust simulation server (on `localhost:8080` inside the container) and the R scheduler (`updateSchedulerRust.R`) under `docker-integrated-start.sh`. The scheduler wakes at 14:45 Berlin time, polls the api-football endpoint for new fixtures, calls the in-process Rust server for Monte Carlo simulations when new results arrive (or on first run), and pushes updated probability matrices to ShinyApps.io. `docker-compose.integrated.yml` is the only orchestrator file. Everything else is deleted.
+
+## Tech Stack
+
+R 4.3.1 (rocker/r-ver:4.3.1), Rust 1.81 (alpine builder stage), Docker + docker-compose v2/v3 syntax, ShinyApps.io as the publication target. No new dependencies. Tests use testthat 3.x but are out of scope for this PRD (see `2026-05-02-ci-rebuild.md` reminder issue).
+
+## The Finding
+
+### Current State
+
+- **Dockerfiles in repo root (7):**
+  - `Dockerfile.integrated` — production (last touched `b11f068`, 2025-08-15)
+  - `Dockerfile.simple` — superseded monolithic experiment (`79d82f6`, 2025-08-03)
+  - `Dockerfile.league` — microservices split, league pod (`b078c84`, 2025-07-29)
+  - `Dockerfile.shiny` — microservices split, shiny pod (`b078c84`, 2025-07-29)
+  - `Dockerfile.optimized` — size-optimization experiment (`852922c`, 2025-07-19)
+  - `DOCKERFILE` — original 2024 build (`b458a84`, 2024-05-30)
+  - `Dockerfile.test` — disabled CI image (`1b23909`, 2025-07-19)
+- **Compose files (2):** `docker-compose.integrated.yml` (production), `docker-compose.simple.yml` (superseded)
+- **Schedulers in `RCode/` (4):** `updateSchedulerRust.R` (production, sourced by `docker-integrated-start.sh:70`), `updateScheduler.R`, `updateSchedulerSimple.R`, `updateSchedulerSimple_local.R` (all unreferenced from production)
+- **Loop orchestrators (2):** `update_all_leagues_loop_rust.R` (sourced by `updateSchedulerRust.R:48`), `update_all_leagues_loop.R` (only sourced by the dead simple-schedulers)
+- **`k8s/` directory:** microservices manifests from refactor `e52f182` ("Refactoring into microservices") — no longer referenced by any production path
+- **`docker/` directory:** `healthcheck-league.R` and `healthcheck-shiny.R`, only used by `Dockerfile.league` / `Dockerfile.shiny`
+- **`scripts/` deployment helpers:** `deploy_pod_lifecycle.sh`, `generate_cronjobs.sh`, `calculate_cronjob_schedules.sh`, `activate_lifecycle.sh`, `emergency_rollback.sh`, `docker_build_all.sh`, `deploy-local.sh`, `status.sh` — all assume the multi-pod k8s architecture
+- **`.github/workflows/`:** 13 disabled files (`*.disabled` and `.bak`); no active workflow
+- **Operator-facing docs claiming production status:**
+  - `docs/deployment/simple-monolithic.md` — describes the *deleted-by-this-PRD* simple stack as "Recommended"
+  - `CLAUDE.md` line 11: "**Simple Deployment** (Recommended): @docs/deployment/simple-monolithic.md"
+  - `docs/deployment/quick-start.md` — references generic `docker-compose build`, doesn't name a file
+
+**Callers of the production scheduler:** `docker-integrated-start.sh:70` is the only caller of `updateSchedulerRust.R`. No other entry point invokes it.
+
+**Second operator entry point (must survive):** `scripts/season_transition.R` is invoked manually before each season rollover (per `docs/SEASON_TRANSITION_UPDATES.md` and the `--non-interactive` flag for Docker/CI use). It sources 15 transition-specific `RCode/` modules plus three reused ones (`retrieveResults.R`, `transform_data.R`, `SpielCPP.R`). It is **not** in the production Docker container's runtime path — it runs locally before a container rebuild — but the files it sources must remain present in the repo. Issue #74 also tracks an enhancement to make the validation/report/cleanup helpers in `season_processor.R` discoverable; this PRD must not break that.
+
+**Test coverage today:** No tests exercise the deployment surface directly. `tests/testthat/test-deployment.R` exists but its scope is unclear and tied to disabled CI (out of scope here).
+
+### Why this is a problem
+
+Six dead Dockerfiles plus a dead k8s directory plus contradictory docs ("Simple Deployment is Recommended") force every contributor — and you, six months from now — to figure out which path is real before changing anything. That's a high tax on every operation. The deletion test: removing `Dockerfile.simple`, `Dockerfile.league`, `Dockerfile.shiny`, `Dockerfile.optimized`, the bare `DOCKERFILE`, `Dockerfile.test`, `docker-compose.simple.yml`, the three dead schedulers, the legacy loop, and the entire `k8s/` directory bundles the deployment-truth complexity from "scattered across 15+ files plus contradictory docs" to "one Dockerfile + one compose + one shell script + one README section." That is a deeper module — smaller interface, same implementation. The current state is also a documentation hazard: `CLAUDE.md` actively misdirects to `simple-monolithic.md`, and a future you will follow that pointer and rebuild the wrong image.
+
+This isn't a refactor of working code — it is a deletion of unused code that's actively confusing. Low risk, high clarity gain.
+
+**The season-transition workflow is the one operator path that looks dead from a code-grep but isn't.** Per `docs/SEASON_TRANSITION_UPDATES.md` and issue #74, `scripts/season_transition.R` is invoked manually between seasons to produce fresh `RCode/TeamList_<year>.csv` files that are then bundled into a new container build. The 15 transition-specific `RCode/` modules and the three reused ones (`retrieveResults.R`, `transform_data.R`, `SpielCPP.R`) are all live. Listed explicitly in the "Files that must survive" subsection below so they can't be swept up in the deletion pass by accident.
+
+### Files that must survive (season-transition operator workflow)
+
+The deletion pass must not touch any of these. They are referenced directly or transitively by `scripts/season_transition.R`. Verified via grep on `source()` calls in the transition entry point and each of its dependencies.
+
+**Entry point:**
+- `scripts/season_transition.R`
+
+**Transition-specific `RCode/` modules (15):**
+- `season_validation.R`, `elo_aggregation.R`, `api_service.R`, `api_helpers.R`, `interactive_prompts.R`, `input_validation.R`, `csv_generation.R`, `file_operations.R`, `season_processor.R`, `league_processor.R`, `error_handling.R`, `logging.R`, `input_handler.R`, `team_config_loader.R`, `team_data_carryover.R`
+
+**Reused by both production and transition (3):**
+- `retrieveResults.R`, `transform_data.R`, **`SpielCPP.R`** ← see note below
+
+**Operator docs that must continue to be accurate:**
+- `docs/SEASON_TRANSITION_UPDATES.md`, `docs/user-guide/season-transition.md` (per issue #74 wrapper-script work)
+
+**Note on `SpielCPP.R`:** This file is sourced by `scripts/season_transition.R:65` (in `existing_modules`). The companion PRD `2026-05-02-simulation-engine-seam.md` originally listed it for deletion as part of retiring the C++ engine — that was incorrect and has been amended. Either `SpielCPP.R` and its transitive Rcpp dependencies survive (decision to make: which?), **or** the season-transition workflow needs to be migrated to use the Rust seam first. The simulation-engine PRD now defers the C++ deletion until that question is answered. For *this* PRD, treat `SpielCPP.R` as a survivor.
+
+**Optional dependency to investigate:** `RCode/csv_generation.R:97–98` conditionally sources a `configmap_generator` script (likely `RCode/configmap_deployment.R`) if found, for k8s ConfigMap generation. This is a soft dependency on the k8s-era code that *this* PRD deletes. Two options: (a) delete `configmap_deployment.R` along with `k8s/` and remove the optional `source()` block from `csv_generation.R` lines 87–106; (b) keep `configmap_deployment.R` if you ever want ConfigMap generation as a future option. **Recommendation: (a).** The k8s deployment is gone; the ConfigMap generator has no consumer. The conditional source code becomes dead weight inside `csv_generation.R`.
+
+## Interface — Before / After
+
+```
+# BEFORE (repo root, deployment-relevant)
+Dockerfile.integrated                # production
+Dockerfile.simple                    # superseded
+Dockerfile.league                    # superseded
+Dockerfile.shiny                     # superseded
+Dockerfile.optimized                 # superseded
+DOCKERFILE                           # legacy (2024)
+Dockerfile.test                      # disabled CI
+docker-compose.integrated.yml        # production
+docker-compose.simple.yml            # superseded
+docker-integrated-start.sh           # production
+docker/healthcheck-league.R          # only used by Dockerfile.league
+docker/healthcheck-shiny.R           # only used by Dockerfile.shiny
+k8s/                                 # microservices experiment, unreferenced
+scripts/deploy_pod_lifecycle.sh      # k8s-era
+scripts/generate_cronjobs.sh         # k8s-era
+scripts/calculate_cronjob_schedules.sh  # k8s-era
+scripts/activate_lifecycle.sh        # k8s-era
+scripts/emergency_rollback.sh        # k8s-era
+scripts/docker_build_all.sh          # k8s-era (builds all 4 images)
+scripts/deploy-local.sh              # k8s-era
+scripts/status.sh                    # k8s-era
+
+# RCode/ (scheduler-relevant)
+RCode/updateSchedulerRust.R          # production (sourced by docker-integrated-start.sh:70)
+RCode/updateScheduler.R              # superseded
+RCode/updateSchedulerSimple.R        # superseded
+RCode/updateSchedulerSimple_local.R  # superseded (and contains a hardcoded local path)
+RCode/update_all_leagues_loop_rust.R # production (sourced by updateSchedulerRust.R:48)
+RCode/update_all_leagues_loop.R      # only sourced by dead schedulers
+
+# AFTER (repo root, deployment-relevant)
+Dockerfile                           # renamed from Dockerfile.integrated
+docker-compose.yml                   # renamed from docker-compose.integrated.yml
+docker-start.sh                      # renamed from docker-integrated-start.sh
+# docker/ directory deleted
+# k8s/ directory deleted
+# All k8s-era scripts/ helpers deleted
+
+# RCode/ (scheduler-relevant)
+RCode/updateScheduler.R              # renamed from updateSchedulerRust.R (the only one left)
+RCode/update_all_leagues_loop.R      # renamed from update_all_leagues_loop_rust.R (the only one left)
+```
+
+**Renames are intentional.** Once there's only one of each, the `Rust` and `integrated` qualifiers are noise — they only made sense when there were alternatives. After the deletion, the unqualified name is the truthful one.
+
+## Design Options Considered
+
+### Option A — Delete dead files in-tree, rename survivors *(recommended)*
+
+> Sketch: Remove the six dead Dockerfiles, the dead compose, the dead `k8s/` and `docker/` directories, the dead scheduler/loop files, the dead `scripts/*.sh` deployment helpers. Rename `Dockerfile.integrated` → `Dockerfile`, compose → `docker-compose.yml`, scheduler → `updateScheduler.R`, loop → `update_all_leagues_loop.R`, start script → `docker-start.sh`. Update `docker-integrated-start.sh` line 70 + `Dockerfile` `CMD` + the new `docker-compose.yml` to reference the new names. Replace `docs/deployment/simple-monolithic.md` and the `CLAUDE.md` pointer with one new operator README that names the single stack.
+> Trade-off: Best clarity gain. Worst short-term risk: a rename can break a script you haven't found yet. Mitigation is grep before merging.
+> Migration cost: ~1–2 hours. Mostly deletion plus 5 small edits to wire renames.
+
+### Option B — Move dead files to `archive/`, no renames
+
+> Sketch: `git mv` the dead files to an `archive/` subdirectory, leave production names alone. Update `CLAUDE.md` to say "production = `Dockerfile.integrated`."
+> Trade-off: Reversible (you could restore an experiment), but leaves the cognitive load nearly intact — the `archive/` directory is still in the tree, still indexed, still searched. Future-you still has to know to ignore it. The `_rust` and `_integrated` qualifiers also persist, perpetuating the false implication that there's a non-Rust, non-integrated path.
+> Migration cost: ~30 minutes. But the value is small.
+
+### Option C — Tag a "pre-cleanup" git ref and delete with renames
+
+> Sketch: Same as Option A, but first create an annotated tag `pre-deployment-cleanup` so the dead files are recoverable from history without polluting the tree.
+> Trade-off: Same clarity gain as A, with explicit recoverability. The cost is one extra git command. This is what I'd actually do.
+> Migration cost: ~1–2 hours plus one tag.
+
+### Recommendation
+
+**Option C** (Option A + a recovery tag). The repo's git history already preserves everything, but an annotated tag `pre-deployment-cleanup-2026-05-02` makes it trivially obvious how to find the experiments later if you ever want to compare approaches. Beyond that, Option A's deletion-with-renames is the right call: the qualifiers (`_rust`, `_integrated`, `_simple`) only meant something when there was a choice. After this PRD, there is no choice, and the qualifiers become misleading. If you change your mind later and want to revive an experiment, the tag is one `git checkout` away.
+
+The trade-off only flips if you genuinely expect to A/B between the simple and integrated stacks again. From your description ("the architecture I currently actually have running in production"), you don't.
+
+## Acceptance Criteria
+
+- [ ] Annotated tag `pre-deployment-cleanup-2026-05-02` exists at the pre-deletion HEAD.
+- [ ] Repo root contains exactly one Dockerfile (`Dockerfile`), one compose file (`docker-compose.yml`), and one start script (`docker-start.sh`).
+- [ ] `RCode/` contains exactly one scheduler file (`updateScheduler.R`) and one loop orchestrator (`update_all_leagues_loop.R`).
+- [ ] `docker/` and `k8s/` directories no longer exist.
+- [ ] All k8s-era helpers in `scripts/` no longer exist (`deploy_pod_lifecycle.sh`, `generate_cronjobs.sh`, `calculate_cronjob_schedules.sh`, `activate_lifecycle.sh`, `emergency_rollback.sh`, `docker_build_all.sh`, `deploy-local.sh`, `status.sh`).
+- [ ] `docker build -f Dockerfile -t league-simulator:test .` succeeds against the renamed `Dockerfile`.
+- [ ] `docker-compose config` against the renamed `docker-compose.yml` parses cleanly and references the new image / start-script names.
+- [ ] `grep -rn "Dockerfile\.\(simple\|league\|shiny\|optimized\|integrated\|test\)\|docker-compose\.\(simple\|integrated\)\|updateSchedulerRust\|updateSchedulerSimple\|update_all_leagues_loop_rust\|docker-integrated-start" .` returns zero matches.
+- [ ] `docs/deployment/simple-monolithic.md` is deleted; a new `docs/deployment/README.md` documents the single stack including the 14:45 Berlin schedule and the Rust + R + Shiny flow.
+- [ ] `CLAUDE.md` line 11 ("Simple Deployment (Recommended)") is replaced with a pointer to the new `docs/deployment/README.md`.
+- [ ] `docs/architecture/overview.md` no longer describes a microservices future as primary architecture (or is footnoted as historical context, not roadmap).
+- [ ] **Season-transition smoke test passes after the cleanup:** `Rscript scripts/season_transition.R 2024 2025 --non-interactive` (against a sandbox with a valid `RAPIDAPI_KEY` or with API mocked) sources all 18 required modules without error and produces a `RCode/TeamList_2025.csv` of the expected shape. *Or* — if running the full transition is impractical — the lighter check `Rscript -e 'source("scripts/season_transition.R")'` aborts on the missing-args check rather than on a `source()` failure (i.e., the file resolves all its dependencies before reaching the args parser).
+- [ ] `RCode/configmap_deployment.R` is deleted and the optional `source()` block in `RCode/csv_generation.R` (lines 87–106) is removed. Re-run the season-transition smoke test to confirm CSV generation still works without the ConfigMap branch.
+
+## Test Strategy
+
+There is no behavioral change here — only deletion and renames. The "test" is that the production image still builds and runs.
+
+### Pin current behavior (regression net, written first)
+
+- **Build the current production image and tag it locally:** `docker build -f Dockerfile.integrated -t league-simulator:pre-cleanup .` Capture the image ID. This is the baseline.
+- **Optional smoke run:** `docker run --rm -e RAPIDAPI_KEY=$RAPIDAPI_KEY -e SHINYAPPS_IO_SECRET=dummy league-simulator:pre-cleanup /app/start.sh` for 30 seconds; confirm Rust server health-check passes (the script logs `✅ Rust server ready on port 8080`). Kill it.
+- **Capture the season-transition baseline:** Run `Rscript scripts/season_transition.R --help` (or with no args, depending on its behavior) and record the output. After the cleanup, the output must be identical — proves no required `source()` was severed. If a real transition fixture is available, run it end-to-end against the pre-cleanup tree and snapshot the resulting CSV.
+
+### Prove the new shape (post-cleanup)
+
+- **Build the renamed image:** `docker build -f Dockerfile -t league-simulator:post-cleanup .` Confirm exit code 0.
+- **`docker-compose config`:** parses the new `docker-compose.yml` without warnings about missing files.
+- **Image diff:** `docker history league-simulator:pre-cleanup` vs `docker history league-simulator:post-cleanup` should differ only in trivial layer hashes (because COPY paths are unchanged) — same number of layers, same package set, same final size ± noise.
+- **Grep test:** the grep in the acceptance criteria returns zero matches — encoded as a CI step or one-line bash check.
+- **Repo-walk test:** `git ls-files | wc -l` decreases by the expected count (the deleted files), and `git status` is clean after the rename commits.
+- **Season-transition smoke test:** rerun the transition baseline command from the pre-cleanup capture; output must match. If a fixture-based end-to-end run is available, the resulting CSV must equal the pre-cleanup snapshot byte-for-byte (or row-for-row if timestamps differ).
+- **Survivor-list grep:** `grep -rln "season_validation\|elo_aggregation\|api_service\|api_helpers\|interactive_prompts\|input_validation\|csv_generation\|file_operations\|season_processor\|league_processor\|error_handling\|input_handler\|team_config_loader\|team_data_carryover\|SpielCPP" RCode/ scripts/` returns the same set of files post-cleanup as pre-cleanup minus the intentionally deleted `configmap_deployment.R` reference and minus any of the dead scheduler files that happened to mention them in passing.
+
+No new testthat tests are needed. This is a deployment cleanup, not a code change.
+
+## Migration Steps
+
+1. **Tag the pre-cleanup state.** `git tag -a pre-deployment-cleanup-2026-05-02 -m "Snapshot before collapsing deployment surface to one stack"`
+2. **Build the current production image as a regression baseline.** Capture the image ID; optionally smoke-run for 30 seconds. **Also capture the season-transition baseline** (run `scripts/season_transition.R` against a known fixture or capture its `--help` / arg-parsing output for byte-comparison later).
+3. **Rename in place (one commit).** `Dockerfile.integrated` → `Dockerfile`, `docker-compose.integrated.yml` → `docker-compose.yml`, `docker-integrated-start.sh` → `docker-start.sh`, `RCode/updateSchedulerRust.R` → `RCode/updateScheduler.R`, `RCode/update_all_leagues_loop_rust.R` → `RCode/update_all_leagues_loop.R`. Update internal references: `Dockerfile` `CMD ["/app/start.sh"]` line, `Dockerfile` `COPY docker-integrated-start.sh /app/start.sh` line, `docker-compose.yml` image/build references, `docker-start.sh` line 70 (`Rscript RCode/updateSchedulerRust.R` → `Rscript RCode/updateScheduler.R`), `RCode/updateScheduler.R` line 48 (the `source()` of the loop file). Build the renamed image; confirm parity with baseline.
+4. **Delete the dead deployment surface (one commit).** Remove `Dockerfile.simple`, `Dockerfile.league`, `Dockerfile.shiny`, `Dockerfile.optimized`, `DOCKERFILE`, `Dockerfile.test`, `docker-compose.simple.yml`, `docker/`, `k8s/`, and the eight k8s-era scripts in `scripts/`. **Also delete `RCode/configmap_deployment.R`** (sole consumer was the k8s ConfigMap workflow; see "Files that must survive" note) and remove the optional `source()` block in `RCode/csv_generation.R` lines 87–106 that referenced it. Re-build to confirm no path was load-bearing. **Re-run the season-transition smoke test** to confirm CSV generation still works without the ConfigMap branch.
+5. **Delete the dead schedulers and loop (one commit).** By step 3, the old `updateScheduler.R` is gone (overwritten by the rename) and the survivors to delete here are `RCode/updateSchedulerSimple.R`, `RCode/updateSchedulerSimple_local.R`, and the now-orphaned `RCode/update_all_leagues_loop.R` *(the old non-rust one — also overwritten by the rename in step 3)*. Net: this step deletes the two `Simple` schedulers only. **Confirm none of these were sourced by `scripts/season_transition.R` or its dependencies** (grep before deleting). Re-run the season-transition smoke test.
+6. **Replace operator docs (one commit).** Delete `docs/deployment/simple-monolithic.md`. Write `docs/deployment/README.md` describing: the single Dockerfile + compose, the 14:45 Berlin schedule, the Rust + R + Shiny flow, the env vars (`RAPIDAPI_KEY`, `SHINYAPPS_IO_SECRET`, `SHINYAPPS_IO_NAME`, `SHINYAPPS_IO_TOKEN`, `SEASON`, `DURATION`), and how to build and run. **Add a section pointing at `docs/SEASON_TRANSITION_UPDATES.md` and `docs/user-guide/season-transition.md`** so the operator-side workflow is signposted from the deployment README. Update `CLAUDE.md` line 11 to point at the new doc.
+7. **Run the grep acceptance checks.** Confirm zero matches for the legacy filenames *and* confirm the survivor-list grep still returns the expected season-transition modules.
+8. **Commit and push.** Optionally, build and push the renamed image to Docker Hub under a new tag if your registry workflow expects it.
+
+## Risks
+
+- **Risk:** A `scripts/` shell helper or markdown doc references a deleted Dockerfile or scheduler by name, and you find out only the next time you try to deploy.
+  - **Mitigation:** Step 7's grep covers source-code references. Also grep `docs/`, `README.md`, and `.claude/` for `Dockerfile.simple`, `updateSchedulerRust`, `k8s/`, etc. before merging.
+- **Risk:** The rename of `updateSchedulerRust.R` → `updateScheduler.R` collides with the *deleted* `updateScheduler.R` in git's view, producing a confusing diff or merge conflict if you have local branches.
+  - **Mitigation:** Do the deletion in step 5 *after* the rename in step 3 has landed on a clean tree. If you have outstanding branches that touch `updateScheduler.R`, rebase them after step 3.
+- **Risk:** `docs/architecture/overview.md` describes a microservices roadmap that is no longer accurate. Future-you reads it and re-introduces complexity.
+  - **Mitigation:** Either update the doc to mark the microservices section as "considered and rejected, see git tag `pre-deployment-cleanup-2026-05-02`" or delete the section. Out of scope for this PRD's acceptance criteria but mentioned in the operator README handoff.
+- **Risk:** ShinyApps.io deployment uses a hardcoded image tag (`chrisschwer/league-simulator:integrated-system-deps` per `docker-compose.integrated.yml:3`) that you'd want to rename too.
+  - **Mitigation:** This is a registry concern, not a repo concern. Either keep the image tag stable (the compose file just references whatever Docker Hub serves) or push under a new tag and update line 3. Decide during step 3.
+- **Risk:** A file in the survivor list ("Files that must survive" subsection) gets caught in the deletion pass because it shares a naming pattern with a dead file (e.g., a future contributor sees `season_processor.R` next to `updateSchedulerSimple.R` and assumes both are equally suspect).
+  - **Mitigation:** The explicit survivor list in this PRD is the contract. The acceptance-criteria smoke test (`Rscript scripts/season_transition.R 2024 2025 --non-interactive`) catches any accidental deletion before merge. Run it after step 4 *and* step 5.
+- **Risk:** The optional `source()` block in `csv_generation.R:87–106` for `configmap_deployment.R` turns out to be load-bearing for some operator workflow we haven't identified.
+  - **Mitigation:** It's already in an `if` branch with a "ConfigMap generation is optional" comment (line 102), so removing it should be safe. If the smoke test in step 4 passes, the path is dead.
+
+## Open Questions
+
+- Do you want to keep the `Dockerfile.integrated` → `Dockerfile` rename, or leave it as `Dockerfile.integrated` so the existing Docker Hub image tag (`chrisschwer/league-simulator:integrated-system-deps`) keeps making sense? My read is rename — the qualifier is no longer meaningful — but you might prefer continuity for the registry side.
+- The ELO data in `RCode/TeamList_2023.csv`, `TeamList_2024.csv`, `TeamList_2025.csv` is committed alongside code. Out of scope for this cleanup, but flag for the next architecture review: data and code probably shouldn't share a directory.
+- `tests/testthat/test-deployment.R` exists. Is it currently green when run locally, or is it part of the disabled-CI fallout? If it asserts things about the deleted Dockerfiles, it'll fail post-cleanup. Decide in step 4 whether to update or delete.
+- The companion PRD `2026-05-02-simulation-engine-seam.md` originally proposed deleting `RCode/SpielCPP.R` and the rest of the C++ engine. Because `scripts/season_transition.R` sources `SpielCPP.R`, that PRD now defers C++ deletion until either (a) `SpielCPP.R` is confirmed safe to delete after a season-transition refactor, or (b) the season-transition workflow is migrated to use the Rust seam. Decision point: should season-transition simulation logic also move to Rust, or should the C++ engine survive specifically as the season-transition's tool? Likely a separate architecture review.
+
+## Adjacent Observations
+
+- The repo root contains ~25 ad-hoc R scripts (`debug_*.R`, `elv_*.R`, `compare_*.R`, `test_*.R`, plus markdown analyses like `MATCH_PROCESSING_ANALYSIS.md`, `RUST_RNG_FIX_RESULTS.md`, `EOD_SUMMARY.md`). They're not deployment-related so they're out of scope here, but they're the same class of clutter and would benefit from the same treatment in a future review.
+- `RCode/retrieveResults_broken.R` is in the production code tree. The naming suggests it should not be there.
+- `.github/workflows/` has 13 disabled files. Those are addressed in the CI rebuild reminder issue, not here.

--- a/docs/prds/2026-05-02-simulation-engine-seam.md
+++ b/docs/prds/2026-05-02-simulation-engine-seam.md
@@ -1,0 +1,235 @@
+# Retire C++ engine, collapse to single Rust simulation seam
+
+**Scope:** `RCode/rust_integration.R`, `RCode/update_all_leagues_loop_rust.R`, and the C++ engine files (`RCode/leagueSimulatorCPP.R`, `RCode/simulationsCPP.R`, `RCode/SaisonSimulierenCPP.R`, `RCode/SpielCPP.R`, `RCode/SpielNichtSimulieren.cpp`, `RCode/cpp_wrappers.R`, `RCode/RcppExports.R`)
+**Date:** 2026-05-02
+**Source:** architecture-review-prd skill
+
+> **⚠️ Constraint discovered after first draft (2026-05-02):** `RCode/SpielCPP.R` is sourced by `scripts/season_transition.R:65` (in `existing_modules`). The original recommendation to delete the entire C++ engine in one pass was wrong — it would break the season-transition operator workflow described in `docs/SEASON_TRANSITION_UPDATES.md` and tracked by issue #74. This PRD now splits into **two phases**: Phase 1 (in scope here) removes the duplicated fallback wiring in the production loop without deleting the C++ source files; Phase 2 (deferred) decides whether `SpielCPP.R` and friends survive permanently as the season-transition's reference engine, or whether season-transition migrates to the Rust seam too. See "Suggested Phasing" at the bottom.
+
+## Goal
+
+**Phase 1:** `leagueSimulatorRust()` is the only simulation entry point invoked by the production loop, called unconditionally by `update_all_leagues_loop()`. The duplicated fallback logic (loop-level `if (use_rust)` plus per-call check inside `leagueSimulatorRust`) is gone. When the Rust server is unavailable, the scheduler fails fast with a clear error. The C++ source files **remain in the repo** because `scripts/season_transition.R` sources `SpielCPP.R`. The brittle `Rcpp::sourceCpp` build step in `Dockerfile.integrated:101–104` is removed only if the production container has no remaining need for the compiled C++ — which it does not, since the deleted fallback was its only consumer.
+
+## Goal — what changes for the user
+
+The production scheduler stops asking the same "is Rust up?" question in three different places, and stops silently substituting C++ for Rust when the answer is no. Failures surface clearly. The Docker build loses the brittle `Rcpp::sourceCpp()` step that already has a documented failure mode (`Dockerfile.integrated:103` — `|| echo "Warning: C++ compilation failed, will rely on Rust engine"`) — because it was only there to enable the now-deleted fallback. The C++ engine source files remain in the repo for the season-transition workflow's use; deciding their long-term fate is Phase 2.
+
+## Architecture
+
+`update_all_leagues_loop()` (renamed from `_rust`) sources `rust_integration.R` once at the top, asserts Rust availability before entering the loop, and calls `leagueSimulatorRust()` directly. There is no `if (use_rust)` branch, no `use_rust` parameter, no C++ source-on-demand. The Rust REST seam at `localhost:8080` is the only simulation interface; the engine is genuinely external from R's perspective. `rust_integration.R` shrinks: `leagueSimulatorRust()` no longer needs its internal C++ fallback (lines 150–156), because the only caller has already asserted Rust is up.
+
+## Tech Stack
+
+R 4.3.1, `httr` and `jsonlite` for the Rust REST client, the existing Rust crate at `league-simulator-rust/`. No new dependencies. **The `Rcpp` package stays in `packagelist.txt`** because `SpielCPP.R` (used by season-transition) is built on it. Removing Rcpp is deferred to Phase 2.
+
+## The Finding
+
+### Current State
+
+- **Public entry point:** `leagueSimulatorRust(season, n, modFactor, homeAdvantage, numberTeams, adjPoints, adjGoals, adjGoalsAgainst, adjGoalDiff)` at `RCode/rust_integration.R:142`. Documented as a "Drop-in Replacement" for `leagueSimulatorCPP`.
+- **Orchestrator:** `update_all_leagues_loop_rust(duration, loops, initial_wait, n, saison, TeamList_file, shiny_directory, use_rust = TRUE)` at `RCode/update_all_leagues_loop_rust.R:4`. Loops over Bundesliga / 2.Bundesliga / 3.Liga; selects the simulator function via `simulator_function <- if (use_rust) leagueSimulatorRust else leagueSimulatorCPP` (line 104).
+- **C++ implementation:** `leagueSimulatorCPP()` at `RCode/leagueSimulatorCPP.R`, plus `simulationsCPP.R`, `SaisonSimulierenCPP.R`, `SpielCPP.R`, and the C++ source `SpielNichtSimulieren.cpp` (compiled at runtime via `Rcpp::sourceCpp`). `cpp_wrappers.R` and `RcppExports.R` are the Rcpp glue.
+- **Two layers of fallback for the same condition:**
+  1. `update_all_leagues_loop_rust.R:30–34` — if `connect_rust_simulator()` returns `FALSE`, set `use_rust <- FALSE` and source the C++ files instead.
+  2. `rust_integration.R:151–156` — `leagueSimulatorRust()` itself calls `connect_rust_simulator()` at the start of *every* call, and falls back to `leagueSimulatorCPP()` per-call if Rust is down.
+- **Production callers:** `RCode/updateSchedulerRust.R:48` (sources `update_all_leagues_loop_rust.R`) and `:152` (sources `rust_integration.R`). The scheduler also calls `connect_rust_simulator()` at line 153 before invoking the loop.
+- **Test callers of CPP files:** `tests/testthat/test-SaisonSimulierenCPP.R`, `test-simulationsCPP.R`, `test-SpielCPP.R`, `test-SpielNichtSimulieren.R` (per the grep in Phase 2). Plus comparison harnesses: `tests/rust/test_rust_vs_cpp_detailed.R`, `tests/rust/test_match_order_verification.R`, `tests/rust/test_rust_elo.R`, `compare_rust_cpp.R`, `compare_rust_vs_r.R` in repo root.
+- **Operator-facing docs that mention the CPP engine:** `docs/architecture/overview.md` ("Rcpp Integration: 100x speedup for critical paths"), `RUST_INTEGRATION.md`, `RUST_RNG_FIX_RESULTS.md`, `Dockerfile.integrated:101–104` ("Compile C++ code (fallback when Rust unavailable)").
+- **Season-transition caller of `SpielCPP.R`:** `scripts/season_transition.R:65` lists `SpielCPP.R` in `existing_modules` (alongside `retrieveResults.R` and `transform_data.R`). The transition workflow is operator-invoked outside the Docker container; per `docs/SEASON_TRANSITION_UPDATES.md` it produces fresh `RCode/TeamList_<year>.csv` files between seasons. **This is the single concrete reason the C++ files cannot be deleted in Phase 1.** Whether `SpielCPP.R` is still actually *needed* by the transition (vs. inherited from when it was the only engine) is the question Phase 2 must answer.
+- **Test coverage today:** Per `CLAUDE.md` and `docs/TEST_FIX_PLAN.md`, "38 tests failing — repair in progress." Specific Rust integration tests exist (`tests/test_rust_integration.R`, `tests/rust/`) but the broader suite is broken. The CPP-specific testthat files presumably worked when the CPP engine was canonical; their status today is unverified.
+
+### Why this is a problem
+
+There are three separate places where "is Rust available?" is asked: `updateSchedulerRust.R:153`, `update_all_leagues_loop_rust.R:31`, and `rust_integration.R:151`. The third one runs *inside every league simulation call*, on every loop iteration, even though the answer was already established at scheduler startup. The fallback path it offers — `leagueSimulatorCPP()` at `rust_integration.R:153` — only works if the C++ files have been sourced, which only happens if `update_all_leagues_loop_rust.R:38` already detected Rust was down. So if Rust dies *between* the loop's check (line 31) and the per-call check (line 151), the fallback fails on a missing function rather than gracefully degrading. The fallback code runs in the wrong place to do its job.
+
+That's the leaky-interface lens: callers must understand a non-obvious ordering (loop-level check sources CPP files; per-call check assumes they're sourced) for the fallback to actually fall back. The deletion test: removing `leagueSimulatorCPP()` and the loop's `if (use_rust)` branch bundles the "which engine?" question to one place — scheduler startup — and lets every downstream call assume the answer.
+
+The deeper finding is about ownership of the engine choice. `b4fbb96` ("Switch to Rust simulation engine in production") and `b11f068` ("Successfully integrate Rust simulation engine in production") committed in August 2025 made the decision. The fallback code is therefore not a runtime safety net — it's an unfinished migration. The cost of keeping it: the brittle `Rcpp::sourceCpp` step at Docker build time (which already documents itself as a possible failure: `Dockerfile.integrated:104`), ~400 lines of C++ glue code in active sources, and the cognitive load of understanding two engines instead of one.
+
+This is also a production stability issue, not just code hygiene. A silent fallback to C++ on every Rust hiccup hides the real problem (Rust server died). Failing fast surfaces it.
+
+## Interface — Before / After
+
+```r
+# BEFORE (RCode/update_all_leagues_loop_rust.R)
+update_all_leagues_loop_rust <- function(duration = 480, loops = 31, initial_wait = 0,
+                                         n = 10000, saison = "2023",
+                                         TeamList_file = "RCode/TeamList_2023.csv",
+                                         shiny_directory = "...",
+                                         use_rust = TRUE) {
+  # ...
+  if (use_rust) {
+    source("RCode/rust_integration.R")
+    if (!connect_rust_simulator()) {
+      use_rust <- FALSE
+    }
+  }
+  if (!use_rust) {
+    Rcpp::sourceCpp("RCode/SpielNichtSimulieren.cpp")
+    source("RCode/leagueSimulatorCPP.R")
+    source("RCode/SaisonSimulierenCPP.R")
+    source("RCode/simulationsCPP.R")
+    source("RCode/SpielCPP.R")
+  }
+  # ...
+  simulator_function <- if (use_rust) leagueSimulatorRust else leagueSimulatorCPP
+  # ...
+}
+
+# BEFORE (RCode/rust_integration.R:142)
+leagueSimulatorRust <- function(season, n = 10000, ...) {
+  if (!connect_rust_simulator()) {
+    message("Falling back to C++ implementation...")
+    return(leagueSimulatorCPP(season, n, ...))    # only works if CPP files were sourced
+  }
+  # ...
+}
+
+# AFTER (RCode/update_all_leagues_loop.R)   # renamed; see deployment-surface PRD
+update_all_leagues_loop <- function(duration = 480, loops = 31, initial_wait = 0,
+                                    n = 10000, saison = "2023",
+                                    TeamList_file = "RCode/TeamList_2023.csv",
+                                    shiny_directory = "...") {
+  # ...
+  source("RCode/rust_integration.R")
+  if (!connect_rust_simulator()) {
+    stop("Rust simulator not available at ", RUST_API_URL,
+         ". Check that the Rust server is running before starting the scheduler.")
+  }
+  # ...
+  source("RCode/prozent.R")
+  source("RCode/retrieveResults.R")
+  source("RCode/Tabelle.R")
+  source("RCode/transform_data.R")
+  source("RCode/updateShiny.R")
+  # ...
+  Ergebnis  <- leagueSimulatorRust(BL,    n = n)
+  Ergebnis2 <- leagueSimulatorRust(BL2,   n = n)
+  Ergebnis3 <- leagueSimulatorRust(Liga3, n = n)
+  Ergebnis3_Aufstieg <- leagueSimulatorRust(Liga3, n = n, adjPoints = adjPoints_Liga3_Aufstieg)
+  # ...
+}
+
+# AFTER (RCode/rust_integration.R:142)
+leagueSimulatorRust <- function(season, n = 10000, ...) {
+  # No connect check, no fallback — caller has already asserted availability.
+  # Rust API call failures still raise via stop() in simulate_league_rust().
+  # ...
+}
+```
+
+**Renames:** the `_rust` qualifier on `update_all_leagues_loop_rust.R` and `update_all_leagues_loop_rust()` becomes meaningless once there's only one engine. The deployment-surface PRD already specifies the file rename to `update_all_leagues_loop.R`; this PRD adds the function rename to `update_all_leagues_loop()`. The exported simulator function `leagueSimulatorRust()` keeps its name — the `Rust` is informative (it tells you where the work happens), unlike `_rust` on the orchestrator (which only existed to distinguish from the dead alternative).
+
+## Design Options Considered
+
+### Option A — Delete C++ entirely, fail fast on Rust outage *(recommended)*
+
+> Sketch: Remove all CPP files. Move the Rust-availability check to the scheduler layer (it's already there at `updateSchedulerRust.R:153`) and the loop entry. On failure, `stop()` instead of falling back. `leagueSimulatorRust()` no longer checks per-call.
+> Trade-off: Loses the safety net entirely. Wins on simplicity, build reliability, and on actually-surfacing Rust outages instead of masking them. The "safety net" is largely illusory anyway because the per-call fallback only works under conditions the surrounding code has to set up.
+> Migration cost: ~2–3 hours. Delete 7 files, edit 2, update tests that reference CPP entry points, decide what to do with `tests/testthat/test-*CPP*.R` (likely delete since the engine is gone), update `Dockerfile.integrated` to remove the `Rcpp::sourceCpp` step.
+
+### Option B — Keep C++ as an isolated alternative implementation, no in-process fallback
+
+> Sketch: Keep CPP files in `RCode/`, source them only in the test suite (for engine-equivalence regression tests), but never in production. Production code calls only `leagueSimulatorRust()`. The seam stays clean; CPP becomes a test-only reference implementation.
+> Trade-off: Preserves the cross-engine equivalence test (which is genuinely valuable — `compare_rust_cpp.R` exists for a reason). Costs you the build-time `Rcpp::sourceCpp` step in Docker (still needed for tests if tests run in CI, though the next-PRD CI rebuild may not include CPP tests). Higher cognitive load than A: contributors still see CPP files in the source tree and may wonder when they're called.
+> Migration cost: ~3 hours. Same deletions of fallback wiring as A, but keeps the CPP files. Need to clearly mark them as test-only (a header comment, a directory move to `RCode/legacy/` or `tests/reference-engine/`).
+
+### Option C — Configurable engine via env var, runtime-pluggable
+
+> Sketch: `SIMULATION_ENGINE=rust|cpp` env var; a small dispatch function returns the right `leagueSimulator*`. No fallback — fail fast on whichever engine is configured.
+> Trade-off: Maximum flexibility, lowest commitment. But you've already committed (per `b4fbb96`); flexibility you don't use is just complexity. The dispatch indirection is the kind of "premature seam" that lives in the codebase forever.
+> Migration cost: ~3–4 hours. Net negative because it preserves both engines plus adds a config layer.
+
+### Recommendation
+
+**Option A.** You've already validated equivalence (`RUST_RNG_FIX_RESULTS.md`, `compare_rust_cpp.R`) and made the production decision. The fallback is the unfinished tail of that migration, not a working safety net. Removing it forces clear failure modes (Rust down → loud error → fix Rust) instead of silent ones (Rust down → CPP fallback maybe works, results silently differ). Option B has appeal for the equivalence tests, but those tests served their purpose during the migration and don't need to keep running once the migration is done. If you want to revisit equivalence later (e.g., comparing Rust against a future engine), the git tag `pre-deployment-cleanup-2026-05-02` from the deployment-surface PRD already preserves the CPP code.
+
+The trade-off would flip if Rust were unstable in production. From the integration commits and the fact you're calling Rust the production engine, it isn't.
+
+## Acceptance Criteria (Phase 1)
+
+- [ ] `RCode/rust_integration.R` no longer calls `leagueSimulatorCPP` (lines 151–156 of the current file are removed).
+- [ ] `RCode/update_all_leagues_loop.R` (renamed by deployment-surface PRD) does not contain the strings `use_rust`, `leagueSimulatorCPP`, `SaisonSimulierenCPP`, `simulationsCPP`, `Rcpp::sourceCpp`. **(`SpielCPP` and `SpielNichtSimulieren` may still appear elsewhere in the repo — they survive in `RCode/` for season-transition.)**
+- [ ] `RCode/update_all_leagues_loop.R` calls `leagueSimulatorRust` directly, not via a `simulator_function` variable.
+- [ ] When the Rust server is unreachable at startup, the scheduler exits with a non-zero status and a message naming `RUST_API_URL`. (Replace silent fallback with loud failure.)
+- [ ] `Dockerfile` no longer contains the `Rcpp::sourceCpp('SpielNichtSimulieren.cpp')` build step (lines 101–104 of `Dockerfile.integrated`). (The container's R runtime never needed it post-fallback-removal — the source files come along via `COPY RCode/`, but they're only used by host-side season-transition runs.)
+- [ ] CPP source files **remain** in `RCode/`: `leagueSimulatorCPP.R`, `simulationsCPP.R`, `SaisonSimulierenCPP.R`, `SpielCPP.R`, `SpielNichtSimulieren.cpp`, `cpp_wrappers.R`, `RcppExports.R`. **Do not delete in Phase 1.**
+- [ ] `tests/testthat/test-*CPP*.R` files: status is verified (run them, see what passes). They may continue to exist as engine tests for the C++ code that backs season-transition. No deletions in Phase 1; CI rebuild (issue #76) is the right place to decide their fate.
+- [ ] `compare_rust_cpp.R`, `compare_rust_vs_r.R`, `tests/rust/test_rust_vs_cpp_detailed.R` are *not* deleted in Phase 1 (originally proposed for deletion; keep until Phase 2 since they exercise the C++ engine that survives).
+- [ ] One end-to-end test exists that runs a single iteration of `update_all_leagues_loop()` against a stubbed or real Rust server and asserts the Shiny output is produced. (This may already exist as `tests/testthat/test-e2e-simulation-workflow.R` — verify and adapt.)
+- [ ] Docker image still builds and the smoke run from the deployment-surface PRD still produces a healthy Rust server + a successful first loop iteration.
+- [ ] **Season-transition smoke test** from the deployment-surface PRD still passes after Phase 1 lands: `Rscript scripts/season_transition.R 2024 2025 --non-interactive` resolves all `source()` calls including `SpielCPP.R`.
+
+## Test Strategy
+
+### Pin current behavior (regression net, written first)
+
+The behavioral contract of `leagueSimulatorRust()` is unchanged — you're only removing fallback code, not simulation code. So the regression net targets the loop, not the simulator.
+
+- `tests/testthat/test-loop-rust-required.R` — start the Rust server, run one iteration of `update_all_leagues_loop_rust()` (current name) against a small fixture league, capture the resulting `Ergebnis` matrix to a snapshot. After the refactor, `update_all_leagues_loop()` (new name) must produce a byte-equivalent `Ergebnis` for the same input. (The Rust engine is deterministic given a fixed seed; if the Rust binary doesn't expose a seed, this becomes a structural assertion — same shape, same column sums to 1 — instead of byte-equality.)
+- **Negative test:** stop the Rust server, invoke `update_all_leagues_loop_rust(use_rust = TRUE)`, assert it currently *silently falls back to CPP and succeeds* (documenting the bad behavior the refactor will change).
+
+### Prove the new shape (post-refactor tests)
+
+- `tests/testthat/test-loop-rust-required.R` — same as above, but with the renamed function. Snapshot must match the pre-refactor capture.
+- **Negative test (updated):** stop the Rust server, invoke `update_all_leagues_loop()`, assert it now `stop()`s with a message containing `RUST_API_URL`. (This test inverts the pre-refactor behavior, which is the point.)
+- `tests/testthat/test-rust-integration-no-fallback.R` — call `leagueSimulatorRust()` directly with the Rust server up, assert it returns the expected matrix shape. Stop the Rust server, call again, assert the API failure surfaces as a `stop()` from `simulate_league_rust` rather than a fallback to CPP.
+
+### What to do with the existing CPP testthat files
+
+`test-SaisonSimulierenCPP.R`, `test-simulationsCPP.R`, `test-SpielCPP.R`, `test-SpielNichtSimulieren.R` exercise functions that **continue to exist in Phase 1** because `SpielCPP.R` is needed by season-transition. Phase 1 does not change them. The CI rebuild (issue #76) is the right time to decide whether they pass against the current code, whether they're worth running in CI, and whether they should migrate or be deleted in Phase 2.
+
+## Migration Steps (Phase 1)
+
+This refactor depends on the deployment-surface PRD landing first (or at least the rename steps from it). If the rename hasn't happened yet, do this PRD's work against the `_rust`-suffixed names, and the deployment-surface rename will sweep through cleanly afterward.
+
+1. **Add the regression snapshot test** described in "Pin current behavior." Run it against the current code; capture the snapshot. Run the negative test; confirm it documents the silent-fallback behavior.
+2. **Move the Rust availability check up.** In `update_all_leagues_loop_rust.R`, replace the `if (use_rust) { ... } if (!use_rust) { source CPP ... }` block (lines 26–45) with a single `source("RCode/rust_integration.R"); if (!connect_rust_simulator()) stop(...)`. Remove the `use_rust` parameter from the function signature. Re-run the regression test (positive case, with Rust up).
+3. **Inline `simulator_function`.** Replace `simulator_function <- if (use_rust) leagueSimulatorRust else leagueSimulatorCPP` and its 4 call sites with direct calls to `leagueSimulatorRust`. Re-run.
+4. **Strip the per-call fallback in `rust_integration.R`.** Delete lines 150–156 of `leagueSimulatorRust()`. Re-run.
+5. **Update the scheduler.** `RCode/updateSchedulerRust.R` already calls `connect_rust_simulator()` at line 153, but logs a warning rather than stopping. Change the warning to a `stop()` so a missing Rust server fails the scheduler at startup, not at first simulation call. Remove the `use_rust = rust_available` argument from the `update_all_leagues_loop_rust()` call (line 172) since the parameter is gone.
+6. **Update the negative regression test** to assert the new fail-fast behavior (it will currently fail because the old code silently fell back). Confirm green.
+7. **Update the Dockerfile.** Remove lines 101–104 of `Dockerfile.integrated` (the `Rcpp::sourceCpp` build step) — the production container no longer needs the compiled C++ object since the fallback is gone. The C++ source files still get COPY-ed via `COPY RCode/`, which is fine; they're just inert in the container. Rebuild the image; confirm it succeeds without the build-time C++ compilation step.
+8. **Smoke test the full container** as in the deployment-surface PRD: build, run, watch the Rust server come up, watch one loop iteration succeed.
+9. **Smoke test the season-transition workflow.** `Rscript scripts/season_transition.R 2024 2025 --non-interactive` (against a fixture or with API mocked) — confirm `SpielCPP.R` still resolves and the transition succeeds. **This is the canary that proves Phase 1 didn't break the operator workflow.**
+10. **Commit and push.**
+
+**Steps 7–11 of the original plan (delete C++ source files, delete CPP testthat files, delete comparison harnesses) are deferred to Phase 2.** Do not run them in Phase 1.
+
+## Risks
+
+- **Risk:** The Rust binary is compiled in stage 1 of `Dockerfile.integrated` and copied into stage 2. If the Rust build fails for any reason, the integrated image now has no fallback — the scheduler will fail-fast.
+  - **Mitigation:** This is the desired behavior, not a bug. Rust build failures should fail the Docker build, not be papered over by a CPP fallback. Add a Rust-build check to the (eventual) CI pipeline (issue #76).
+- **Risk:** A future Rust server outage (network blip, OOM kill, deploy mishap) now produces a hard scheduler failure instead of degraded operation.
+  - **Mitigation:** This is a feature trade-off, not a bug. The current "silent fallback" hides outages and produces results from the wrong engine. Loud failures are a better signal. The retry logic in `docker-integrated-start.sh:48–94` (`MAX_RETRIES=5`, `RETRY_DELAY=30`) already restarts the scheduler — and now the Rust server too if `kill -0 $RUST_PID` shows it's dead. So the operational effect of a single Rust crash is the same as today: the wrapper restarts both. The change is at the *single-loop-iteration* layer, where you get a clear error instead of a silent engine swap.
+- **Risk:** Removing the `Rcpp::sourceCpp` step from the Dockerfile (step 7) leaves the C++ source files in `RCode/` un-compiled inside the container. If anything *inside* the container ever invokes `SpielCPP.R` (e.g., a debugging exec into the running container), it will fail.
+  - **Mitigation:** Nothing in the production runtime invokes `SpielCPP.R` after the fallback removal. Season-transition runs on the host, not in the container. If a future workflow requires in-container C++ compilation, re-add the build step then. Phase 1 simply stops paying the build-time cost for an unused artifact.
+- **Risk:** Step 9's season-transition smoke test fails because some other dependency was inadvertently affected — e.g., `SpielCPP.R` itself depends on `SpielNichtSimulieren.cpp` being compiled, and the host environment doesn't have `Rcpp` configured.
+  - **Mitigation:** This is a real concern. Before step 7, run the smoke test on a clean checkout to confirm it passes today (proving the host environment can build the C++ code). If it doesn't pass *today* either, season-transition is already broken locally, which is a separate problem to surface (not caused by this PRD). If it passes today and fails after step 7, something is wrong with the changes — investigate before merging.
+
+## Open Questions
+
+- Does the Rust binary expose a deterministic-seed flag? If yes, the regression-snapshot test (step 1) can use byte-equality. If no, the test asserts only structural properties (matrix shape, row sums = 1, ranking order stable across runs with high probability). Worth checking the Rust crate's CLI help during step 1.
+- `tests/testthat/test-e2e-simulation-workflow.R` may already cover the loop end-to-end. Read it during step 1 to decide whether the new `test-loop-rust-required.R` duplicates it; if so, extend the existing test instead of adding a new file.
+- **Phase 2 question:** Does `scripts/season_transition.R` actually *use* `SpielCPP.R`, or did it inherit the source line from when C++ was the only engine? Quick test: comment out the `SpielCPP.R` source in `existing_modules` and run a transition. If it still works, `SpielCPP.R` was vestigial and can join the C++ deletion in Phase 2. If it fails, the season-transition workflow has a real C++ dependency and Phase 2 must either (a) keep the C++ engine indefinitely as season-transition's tool, or (b) migrate season-transition to call the Rust seam.
+
+## Suggested Phasing
+
+This refactor splits cleanly along the production/operator boundary.
+
+**Phase 1 (this PRD).** Remove duplicated fallback wiring, fail fast on Rust unavailability, drop the unnecessary Docker build step. C++ source files remain. Production code calls Rust unconditionally; season-transition continues to source `SpielCPP.R` as before. Smallest valuable, shippable slice. Addresses the immediate architectural smell (three fallback checks, brittle Docker step) without breaking the operator workflow.
+
+**Phase 2 (re-derive after Phase 1 lands and you've verified the production path is stable).** Decide the long-term fate of the C++ engine, given what season-transition actually needs. Concrete questions to answer at that point:
+- Does season-transition genuinely call into `SpielCPP.R`, or just source it without invocation? (See Open Questions above.)
+- If genuinely needed: is "C++ engine permanently survives as season-transition's tool" the right answer (acceptable maintenance burden, clear ownership), or should season-transition migrate to the Rust seam (more invasive but consolidates the engine to one)?
+- If not genuinely needed: delete `SpielCPP.R` and the rest of the C++ engine, the Rcpp dependency from `packagelist.txt`/`DESCRIPTION`, the CPP testthat files, and the comparison harnesses — exactly the deletions originally proposed in the first draft of this PRD.
+
+**Don't pre-plan Phase 2 in detail now.** The post-Phase-1 codebase will look different (no more fallback wiring, possibly some additional discoveries about `SpielCPP.R`'s actual usage), and re-running `architecture-review-prd` against that state will produce a sharper PRD than guessing now would.
+
+## Adjacent Observations
+
+- `compare_rust_cpp.R`, `compare_rust_vs_r.R`, and `compare_working.R` are in the repo root. They're tooling, not production. Same class as the `debug_*.R` and `elv_*.R` clutter flagged in the deployment-surface PRD. Out of scope here, in scope for a "repo root hygiene" review later.
+- `RCode/retrieveResults_broken.R` lives next to `retrieveResults.R`. The naming is itself a smell — broken code shouldn't be in the production source tree, even with a `_broken` suffix. Out of scope for this PRD; flag for a future cleanup pass.
+- `Dockerfile.integrated:42–88` does R package installation in three stages (core / shiny / rest) with retry-and-fallback logic for binary vs source builds. That's a separate fragility worth a future review — likely related to whatever broke CI originally.
+- The Rust-available check is currently *also* duplicated between `updateSchedulerRust.R:153` and (post-refactor) `update_all_leagues_loop.R`. After this PRD lands, consider: should the loop trust the scheduler's check, or check independently for defense-in-depth? The current PRD keeps both for safety; if you want one, drop the loop's check (the scheduler is the entry point).
+- The season-transition's reliance on `SpielCPP.R` (discovered while patching this PRD) is itself an architectural observation worth recording: the operator workflow embeds an engine choice that the production workflow has already moved past. If season-transition were to migrate to the Rust seam, it would also gain the Rust engine's performance characteristics — relevant if a transition's simulation step is slow today.

--- a/docs/superpowers/plans/2026-05-02-deployment-surface-collapse.md
+++ b/docs/superpowers/plans/2026-05-02-deployment-surface-collapse.md
@@ -1,0 +1,1166 @@
+# Collapse Deployment Surface to One Production Stack — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reduce the repo to exactly one production deployment stack — `Dockerfile` + `docker-compose.yml` + `docker-start.sh` + `RCode/updateScheduler.R` — by deleting six dead Dockerfiles, the dead compose, the `k8s/` and `docker/` directories, eight k8s-era shell scripts, three dead R schedulers, the legacy loop file, and `RCode/configmap_deployment.R`. Rename surviving production files to drop the now-misleading `_rust` / `_integrated` qualifiers. The season-transition operator workflow (`scripts/season_transition.R`) must continue to work.
+
+**Architecture:** Pure deletion + rename. No behavioral changes. Each task produces a single git commit. Tasks are ordered so the production Docker image stays buildable at every commit, and the season-transition smoke test passes after every deletion task. The "tests" here are not testthat tests — they are command-level checks (`docker build`, `docker-compose config`, `Rscript -e 'source(...)'`) that prove no required file was severed.
+
+**Tech Stack:** Docker, docker-compose v2/v3, R 4.3.1 + Rscript, bash. No new dependencies.
+
+**Reference:** PRD at `docs/prds/2026-05-02-deployment-surface-collapse.md` (also GitHub issue #78). Companion PRD `docs/prds/2026-05-02-simulation-engine-seam.md` (issue #77) is independent — do not interleave.
+
+**Doc-cleanup is out of scope.** Many docs in `docs/deployment/` (and a few in `tests/`, `RUST_INTEGRATION.md`, `PRD_ISSUE_1_monolithic_deployment.md`, `.claude/`) reference the old layout. The acceptance grep in this plan is **scoped to source code only** (`RCode/`, `scripts/`, `tests/testthat/`, root-level `Dockerfile*`/`docker-compose*`/`*.sh`). A separate follow-up GitHub issue tracks doc cleanup. Do not expand scope mid-plan.
+
+**Survivor list — DO NOT DELETE:** `scripts/season_transition.R`, plus the 15 `RCode/` modules it sources (`season_validation.R`, `elo_aggregation.R`, `api_service.R`, `api_helpers.R`, `interactive_prompts.R`, `input_validation.R`, `csv_generation.R`, `file_operations.R`, `season_processor.R`, `league_processor.R`, `error_handling.R`, `logging.R`, `input_handler.R`, `team_config_loader.R`, `team_data_carryover.R`), plus `retrieveResults.R`, `transform_data.R`, **`SpielCPP.R`**, and the rest of the C++ engine (`leagueSimulatorCPP.R`, `simulationsCPP.R`, `SaisonSimulierenCPP.R`, `SpielNichtSimulieren.cpp`, `cpp_wrappers.R`, `RcppExports.R`). The companion PRD #77 will decide the C++ engine's long-term fate; this plan touches none of it.
+
+---
+
+## File Inventory
+
+### Files renamed (5)
+
+| Before | After |
+|---|---|
+| `Dockerfile.integrated` | `Dockerfile` |
+| `docker-compose.integrated.yml` | `docker-compose.yml` |
+| `docker-integrated-start.sh` | `docker-start.sh` |
+| `RCode/updateSchedulerRust.R` | `RCode/updateScheduler.R` |
+| `RCode/update_all_leagues_loop_rust.R` | `RCode/update_all_leagues_loop.R` |
+
+### Files modified to follow renames (5)
+
+- `Dockerfile` (line 107: `COPY docker-integrated-start.sh /app/start.sh` → `COPY docker-start.sh /app/start.sh`)
+- `docker-start.sh` (line 70: `Rscript RCode/updateSchedulerRust.R` → `Rscript RCode/updateScheduler.R`)
+- `RCode/updateScheduler.R` (line 48: `source("RCode/update_all_leagues_loop_rust.R")` → `source("RCode/update_all_leagues_loop.R")`; line 164: function call `update_all_leagues_loop_rust(` → `update_all_leagues_loop(`)
+- `RCode/update_all_leagues_loop.R` (line 4: function definition `update_all_leagues_loop_rust <- function(` → `update_all_leagues_loop <- function(`)
+- `CLAUDE.md` (lines 19, 20: change `Dockerfile.simple` / `docker-compose.simple.yml` → `Dockerfile` / `docker-compose.yml`; line 70: replace `simple-monolithic.md` pointer with `README.md` pointer)
+
+### Files deleted (24)
+
+**Dockerfiles (6):** `Dockerfile.simple`, `Dockerfile.league`, `Dockerfile.shiny`, `Dockerfile.optimized`, `DOCKERFILE`, `Dockerfile.test`
+
+**Compose (1):** `docker-compose.simple.yml`
+
+**Directories (2):** `docker/` (contains `healthcheck-league.R`, `healthcheck-shiny.R`), `k8s/` (microservices manifests)
+
+**Scripts (8):** `scripts/deploy_pod_lifecycle.sh`, `scripts/generate_cronjobs.sh`, `scripts/calculate_cronjob_schedules.sh`, `scripts/activate_lifecycle.sh`, `scripts/emergency_rollback.sh`, `scripts/docker_build_all.sh`, `scripts/deploy-local.sh`, `scripts/status.sh`
+
+**R files (4):** `RCode/updateSchedulerSimple.R`, `RCode/updateSchedulerSimple_local.R`, `RCode/configmap_deployment.R`, `RCode/test_scheduler_now.R` *(this last one is a test utility for the dead simple scheduler; verify in Task 7)*
+
+**Docs (1):** `docs/deployment/simple-monolithic.md`
+
+### Files created (1)
+
+- `docs/deployment/README.md` (new operator README documenting the single stack)
+
+### Files modified beyond the rename follow-ups (1)
+
+- `RCode/csv_generation.R` (lines 79–109: remove the optional `tryCatch` block that conditionally sources `k8s/templates/configmap-generator.R`)
+
+---
+
+## Task 1: Pre-flight Verification + Recovery Tag
+
+**Goal:** Capture a recoverable git ref and confirm the production stack builds *before* any change. Establishes the baseline that subsequent tasks will be measured against.
+
+**Files:**
+- No file changes. This task is git + docker-only.
+
+- [ ] **Step 1: Confirm clean working tree**
+
+```bash
+git status --short
+```
+
+Expected output: empty (or only the two PRDs already on disk in `docs/prds/`). If anything else is present, stop and ask before continuing.
+
+- [ ] **Step 2: Confirm we're on `main` and up to date**
+
+```bash
+git branch --show-current
+git fetch origin
+git status -uno
+```
+
+Expected: `main`; `Your branch is up to date with 'origin/main'.` If not, ask before continuing.
+
+- [ ] **Step 3: Create the recovery tag**
+
+```bash
+git tag -a pre-deployment-cleanup-2026-05-02 -m "Snapshot before collapsing deployment surface to one stack (issue #78)"
+```
+
+- [ ] **Step 4: Verify the tag exists locally**
+
+```bash
+git tag -l pre-deployment-cleanup-2026-05-02
+```
+
+Expected output: `pre-deployment-cleanup-2026-05-02`
+
+- [ ] **Step 5: Push the tag to the remote**
+
+```bash
+git push origin pre-deployment-cleanup-2026-05-02
+```
+
+Expected: `* [new tag]         pre-deployment-cleanup-2026-05-02 -> pre-deployment-cleanup-2026-05-02`
+
+- [ ] **Step 6: Build the current production image as a baseline**
+
+```bash
+docker build -f Dockerfile.integrated -t league-simulator:pre-cleanup .
+```
+
+Expected: build succeeds, ends with a line like `Successfully tagged league-simulator:pre-cleanup`. **This may take 5–10 minutes** — the Dockerfile installs the full R package list. If the build fails, stop and report the failure; the production image is broken in a way unrelated to this plan, and that is a blocker.
+
+- [ ] **Step 7: Capture the baseline image ID**
+
+```bash
+docker images league-simulator:pre-cleanup --format '{{.ID}}'
+```
+
+Record the ID (e.g., `sha256:abc123...`). You'll compare against this in Task 8.
+
+- [ ] **Step 8: Capture the season-transition baseline**
+
+```bash
+Rscript -e 'tryCatch(source("scripts/season_transition.R"), error = function(e) cat("EXPECTED ARGS-MISSING ERROR:", e$message, "\n"))' 2>&1 | tee /tmp/season-transition-baseline.txt
+```
+
+Expected: the script sources its 18 required modules (15 transition-specific + `retrieveResults.R`, `transform_data.R`, `SpielCPP.R`), then fails with an args-related error like `Error: usage: Rscript season_transition.R <source_season> <target_season>` *or similar* (it will not have any required-module-not-found warnings). The output goes to `/tmp/season-transition-baseline.txt` for later comparison. Note: if your environment lacks `Rcpp` or can't compile `SpielCPP.R`, this baseline may legitimately fail; if so, document that and skip the season-transition smoke checks in later tasks (the plan's deletions don't touch any season-transition file).
+
+- [ ] **Step 9: No commit needed**
+
+This task only created a git tag (no working-tree change). No commit.
+
+---
+
+## Task 2: Rename `Dockerfile.integrated` → `Dockerfile` and update internal references
+
+**Goal:** Rename the production Dockerfile to its unqualified name. Update the `COPY` line that still references the old start-script name (which we'll rename in Task 3). After this task, the build still works because the start script hasn't been renamed yet — both the new `Dockerfile` and the old `docker-integrated-start.sh` co-exist.
+
+**Files:**
+- Delete: `DOCKERFILE` (legacy all-caps file, pulled forward from Task 6 to resolve case-insensitive-filesystem collision)
+- Rename: `Dockerfile.integrated` → `Dockerfile`
+- Modify: `Dockerfile` line 107
+
+- [ ] **Step 0: Delete the legacy `DOCKERFILE` first (case-insensitive filesystem workaround)**
+
+On macOS APFS (case-insensitive by default), `git mv Dockerfile.integrated Dockerfile` fails because the OS sees the existing `DOCKERFILE` (all-caps) at the same path. The legacy `DOCKERFILE` was already slated for deletion in Task 6; pulling it forward here unblocks the rename without any change in semantics.
+
+```bash
+git rm DOCKERFILE
+```
+
+Verify with `ls -la | grep -i ^dockerfile` — `DOCKERFILE` should be gone; only the `Dockerfile.X` family should remain.
+
+- [ ] **Step 1: Rename the Dockerfile**
+
+```bash
+git mv Dockerfile.integrated Dockerfile
+```
+
+- [ ] **Step 2: Verify the rename**
+
+```bash
+ls Dockerfile Dockerfile.integrated 2>&1
+```
+
+Expected: `Dockerfile` exists; `ls: Dockerfile.integrated: No such file or directory`.
+
+- [ ] **Step 3: Inspect the unchanged content (sanity check)**
+
+```bash
+sed -n '105,120p' Dockerfile
+```
+
+Expected: lines 107 (`COPY docker-integrated-start.sh /app/start.sh`), 108 (`RUN chmod +x /app/start.sh`), 119 (`CMD ["/app/start.sh"]`). The `CMD` already uses the in-container path `/app/start.sh` and does not need to change. Only the `COPY` line at 107 names the host file we'll rename in Task 3 — but **leave it alone for now** so the build still works.
+
+- [ ] **Step 4: Build with the new name to confirm parity**
+
+```bash
+docker build -f Dockerfile -t league-simulator:rename-test-1 .
+```
+
+Expected: build succeeds. Cache should make this fast (seconds, not minutes) since the Dockerfile content is byte-identical.
+
+- [ ] **Step 5: Commit (single commit covers both the legacy-DOCKERFILE deletion and the rename)**
+
+```bash
+git commit -m "refactor: rename Dockerfile.integrated to Dockerfile
+
+Part of deployment surface collapse (issue #78). The 'integrated' qualifier
+only made sense when there were alternative Dockerfiles. After the cleanup,
+Dockerfile is the only one.
+
+Also delete the legacy uppercase DOCKERFILE (a 2024 single-stage build
+superseded by the multi-stage Dockerfile.integrated). It was already
+slated for deletion in Task 6; pulled forward here to resolve a
+case-insensitive-filesystem collision with the rename target on macOS APFS."
+```
+
+Note: `git rm DOCKERFILE` (Step 0) and `git mv` (Step 1) already staged the deletion and the rename, so a single `git commit` (no `git add`) captures both.
+
+---
+
+## Task 3: Rename `docker-integrated-start.sh` → `docker-start.sh` and update Dockerfile
+
+**Goal:** Rename the start script and fix the `COPY` reference in the new `Dockerfile` so the build keeps working.
+
+**Files:**
+- Rename: `docker-integrated-start.sh` → `docker-start.sh`
+- Modify: `Dockerfile` line 107
+
+- [ ] **Step 1: Rename the script**
+
+```bash
+git mv docker-integrated-start.sh docker-start.sh
+```
+
+- [ ] **Step 2: Update the `COPY` line in `Dockerfile`**
+
+Edit `Dockerfile` line 107 to replace the old script name. Use `sed` for precision:
+
+```bash
+sed -i.bak 's|COPY docker-integrated-start.sh /app/start.sh|COPY docker-start.sh /app/start.sh|' Dockerfile && rm Dockerfile.bak
+```
+
+- [ ] **Step 3: Verify the edit**
+
+```bash
+grep -n "docker.*start" Dockerfile
+```
+
+Expected output (one line):
+```
+107:COPY docker-start.sh /app/start.sh
+```
+
+- [ ] **Step 4: Build to confirm the renamed script still gets copied**
+
+```bash
+docker build -f Dockerfile -t league-simulator:rename-test-2 .
+```
+
+Expected: build succeeds. The `COPY` step will re-run because its source filename changed (cache invalidated), but later steps should cache.
+
+- [ ] **Step 5: Verify the script is in the image**
+
+```bash
+docker run --rm --entrypoint sh league-simulator:rename-test-2 -c "ls -la /app/start.sh"
+```
+
+Expected: `-rwxr-xr-x ... /app/start.sh`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Dockerfile docker-start.sh
+git commit -m "refactor: rename docker-integrated-start.sh to docker-start.sh
+
+Update COPY reference in Dockerfile to match. The 'integrated' qualifier
+was only meaningful when there were other start scripts; now there's
+only one. (issue #78)"
+```
+
+---
+
+## Task 4: Rename the Rust scheduler and loop files (and the loop function)
+
+**Goal:** Rename `updateSchedulerRust.R` → `updateScheduler.R` and `update_all_leagues_loop_rust.R` → `update_all_leagues_loop.R`. **Also rename the function `update_all_leagues_loop_rust` to `update_all_leagues_loop`** in both its definition and its call site. Update `docker-start.sh` line 70 to invoke the renamed scheduler.
+
+**Files:**
+- Rename: `RCode/updateSchedulerRust.R` → `RCode/updateScheduler.R`
+- Rename: `RCode/update_all_leagues_loop_rust.R` → `RCode/update_all_leagues_loop.R`
+- Modify: `RCode/updateScheduler.R` (line 48: `source` call; line 164: function call)
+- Modify: `RCode/update_all_leagues_loop.R` (line 4: function definition)
+- Modify: `docker-start.sh` (line 70: `Rscript` invocation)
+
+- [ ] **Step 1: Rename the scheduler file**
+
+```bash
+git mv RCode/updateSchedulerRust.R RCode/updateScheduler.R
+```
+
+- [ ] **Step 2: Rename the loop file**
+
+```bash
+git mv RCode/update_all_leagues_loop_rust.R RCode/update_all_leagues_loop.R
+```
+
+- [ ] **Step 3: Update the `source()` call in the renamed scheduler (line 48)**
+
+```bash
+sed -i.bak 's|source("RCode/update_all_leagues_loop_rust.R")|source("RCode/update_all_leagues_loop.R")|' RCode/updateScheduler.R && rm RCode/updateScheduler.R.bak
+```
+
+- [ ] **Step 4: Update the function call in the renamed scheduler (line 164)**
+
+```bash
+sed -i.bak 's|update_all_leagues_loop_rust(|update_all_leagues_loop(|' RCode/updateScheduler.R && rm RCode/updateScheduler.R.bak
+```
+
+- [ ] **Step 5: Update the function definition in the renamed loop (line 4)**
+
+```bash
+sed -i.bak 's|^update_all_leagues_loop_rust <- function|update_all_leagues_loop <- function|' RCode/update_all_leagues_loop.R && rm RCode/update_all_leagues_loop.R.bak
+```
+
+- [ ] **Step 6: Update the `Rscript` invocation in `docker-start.sh` (line 70)**
+
+```bash
+sed -i.bak 's|Rscript RCode/updateSchedulerRust.R|Rscript RCode/updateScheduler.R|' docker-start.sh && rm docker-start.sh.bak
+```
+
+- [ ] **Step 7: Verify all five edits landed**
+
+```bash
+grep -n "update_all_leagues_loop\|updateScheduler" RCode/updateScheduler.R RCode/update_all_leagues_loop.R docker-start.sh
+```
+
+Expected output (no occurrences of `_rust` should appear, and the function name should be the unqualified `update_all_leagues_loop`):
+
+```
+RCode/updateScheduler.R:48:source("RCode/update_all_leagues_loop.R")
+RCode/updateScheduler.R:164:  update_all_leagues_loop(
+RCode/update_all_leagues_loop.R:4:update_all_leagues_loop <- function(duration = 480, loops = 31, initial_wait = 0,
+docker-start.sh:70:        Rscript RCode/updateScheduler.R
+```
+
+If any line still contains `_rust`, fix it before continuing.
+
+- [ ] **Step 8: Verify R can parse the renamed scheduler (syntax check)**
+
+```bash
+Rscript -e 'parse("RCode/updateScheduler.R"); parse("RCode/update_all_leagues_loop.R"); cat("OK\n")'
+```
+
+Expected output: `OK`. If R reports a parse error, the `sed` edit corrupted something — inspect and fix.
+
+- [ ] **Step 9: Build the Docker image to confirm the renamed files still work end-to-end**
+
+```bash
+docker build -f Dockerfile -t league-simulator:rename-test-3 .
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 10: Verify the renamed scheduler is the one in the image**
+
+```bash
+docker run --rm --entrypoint sh league-simulator:rename-test-3 -c "ls /app/RCode/updateScheduler*.R /app/RCode/update_all_leagues_loop*.R"
+```
+
+Expected: shows `updateScheduler.R`, `updateSchedulerSimple.R`, `updateSchedulerSimple_local.R`, `update_all_leagues_loop.R`, `update_all_leagues_loop_rust.R` — wait, the `_rust` versions should be gone. **Re-check Step 1 and Step 2 if they still appear.** The original `update_all_leagues_loop.R` (the dead non-rust one) will also appear in this listing — that's expected, it gets deleted in Task 6. Important: do not see `updateSchedulerRust.R` or `update_all_leagues_loop_rust.R`.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add RCode/updateScheduler.R RCode/update_all_leagues_loop.R docker-start.sh
+git commit -m "refactor: rename Rust scheduler and loop to unqualified names
+
+- updateSchedulerRust.R -> updateScheduler.R
+- update_all_leagues_loop_rust.R -> update_all_leagues_loop.R
+- Rename the loop function update_all_leagues_loop_rust() to update_all_leagues_loop()
+- Update source() and function-call references
+- Update docker-start.sh to invoke the renamed scheduler
+
+The '_rust' qualifier only made sense when there was a non-Rust path. After
+the cleanup that path is gone. (issue #78)"
+```
+
+---
+
+## Task 5: Rename `docker-compose.integrated.yml` → `docker-compose.yml`
+
+**Goal:** Rename the production compose file. The compose file references the image by tag (`chrisschwer/league-simulator:integrated-system-deps`), not by Dockerfile path, so no internal edit is needed.
+
+**Files:**
+- Rename: `docker-compose.integrated.yml` → `docker-compose.yml`
+
+- [ ] **Step 1: Inspect the compose file for any Dockerfile path references that need updating**
+
+```bash
+grep -n "Dockerfile\|dockerfile" docker-compose.integrated.yml
+```
+
+Expected: one match in the optional `rust-simulator` service block (line ~36: `dockerfile: Dockerfile`) — that's a relative reference inside `league-simulator-rust/`, unrelated to the rename. No edit needed.
+
+- [ ] **Step 2: Rename**
+
+```bash
+git mv docker-compose.integrated.yml docker-compose.yml
+```
+
+- [ ] **Step 3: Validate the renamed compose file parses**
+
+```bash
+docker-compose -f docker-compose.yml config > /dev/null
+```
+
+Expected: exit code 0. (You can drop the `-f docker-compose.yml` since `docker-compose` defaults to that filename, but being explicit makes the intent obvious.)
+
+- [ ] **Step 4: Verify with the default filename**
+
+```bash
+docker-compose config > /dev/null
+```
+
+Expected: exit code 0. Now docker-compose finds it without `-f`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docker-compose.yml
+git commit -m "refactor: rename docker-compose.integrated.yml to docker-compose.yml
+
+Production now uses the default compose filename. (issue #78)"
+```
+
+---
+
+## Task 6: Delete dead Dockerfiles, dead compose, dead R schedulers, and dead loop
+
+**Goal:** Remove the six superseded Dockerfiles, the superseded compose, and the four dead R files (two `Simple` schedulers, the original `updateScheduler.R` overwritten in Task 4 — wait, that one was overwritten by `git mv`, so it's already gone — and the dead non-rust `update_all_leagues_loop.R` overwritten in Task 4). Verify nothing the production stack or season-transition needs is being deleted.
+
+**Files:**
+- Delete: `Dockerfile.simple`, `Dockerfile.league`, `Dockerfile.shiny`, `Dockerfile.optimized`, `Dockerfile.test`  *(`DOCKERFILE` was pulled forward to Task 2 due to case-insensitive-filesystem collision)*
+- Delete: `docker-compose.simple.yml`
+- Delete: `RCode/updateSchedulerSimple.R`, `RCode/updateSchedulerSimple_local.R`
+
+> **Note on the original `RCode/updateScheduler.R` and `RCode/update_all_leagues_loop.R`:** Both were overwritten by the `git mv` operations in Task 4 (because the renames pointed to filenames that already existed as dead files). Git treats this as "rename + delete" in one step. So there is nothing to delete here for those two files — they're already gone.
+
+- [ ] **Step 1: Confirm the survivor list before deleting anything**
+
+```bash
+grep -E "season_validation|elo_aggregation|api_service|api_helpers|interactive_prompts|input_validation|csv_generation|file_operations|season_processor|league_processor|error_handling|input_handler|team_config_loader|team_data_carryover|SpielCPP" Dockerfile.simple Dockerfile.league Dockerfile.shiny Dockerfile.optimized DOCKERFILE Dockerfile.test docker-compose.simple.yml RCode/updateSchedulerSimple.R RCode/updateSchedulerSimple_local.R 2>/dev/null
+```
+
+Expected: zero matches (or only matches that are clearly not source-import statements). If any of these dead files import a survivor module by name, stop and investigate — the survivor may have a hidden second consumer.
+
+- [ ] **Step 2: Delete the five remaining dead Dockerfiles** *(legacy `DOCKERFILE` already deleted in Task 2)*
+
+```bash
+git rm Dockerfile.simple Dockerfile.league Dockerfile.shiny Dockerfile.optimized Dockerfile.test
+```
+
+Expected output: five `rm 'Dockerfile.…'` lines.
+
+- [ ] **Step 3: Delete the dead compose file**
+
+```bash
+git rm docker-compose.simple.yml
+```
+
+- [ ] **Step 4: Delete the two `Simple` schedulers**
+
+```bash
+git rm RCode/updateSchedulerSimple.R RCode/updateSchedulerSimple_local.R
+```
+
+- [ ] **Step 5: Verify no Dockerfile-related files remain except `Dockerfile`**
+
+```bash
+ls -1 | grep -i "^dockerfile\|^docker-compose"
+```
+
+Expected output (exactly two lines):
+```
+Dockerfile
+docker-compose.yml
+```
+
+- [ ] **Step 6: Verify the production scheduler/loop are the only ones in `RCode/`**
+
+```bash
+ls RCode/updateScheduler*.R RCode/update_all_leagues_loop*.R
+```
+
+Expected output (exactly two files):
+```
+RCode/updateScheduler.R
+RCode/update_all_leagues_loop.R
+```
+
+- [ ] **Step 7: Rebuild the production image to confirm nothing load-bearing was deleted**
+
+```bash
+docker build -f Dockerfile -t league-simulator:after-deletes-1 .
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 8: Run the season-transition smoke check**
+
+```bash
+Rscript -e 'tryCatch(source("scripts/season_transition.R"), error = function(e) cat("ERROR:", e$message, "\n"))' 2>&1 | tee /tmp/season-transition-after-task-6.txt
+```
+
+Expected: same error message as the baseline captured in Task 1, Step 8 (`/tmp/season-transition-baseline.txt`). The script must reach the args-parsing failure, **not** fail on a missing `source()`. Diff for sanity:
+
+```bash
+diff /tmp/season-transition-baseline.txt /tmp/season-transition-after-task-6.txt
+```
+
+Expected: no meaningful diff (timestamps in messages may differ; module-load lines should be identical).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add -A
+git commit -m "chore: delete dead Dockerfiles, compose, and Simple schedulers
+
+Removed:
+- Dockerfile.simple, Dockerfile.league, Dockerfile.shiny,
+  Dockerfile.optimized, DOCKERFILE, Dockerfile.test
+- docker-compose.simple.yml
+- RCode/updateSchedulerSimple.R, RCode/updateSchedulerSimple_local.R
+
+The original RCode/updateScheduler.R and RCode/update_all_leagues_loop.R
+were overwritten by the renames in the previous task (git treated them
+as rename targets), so they're already gone.
+
+Recovery available via tag pre-deployment-cleanup-2026-05-02. (issue #78)"
+```
+
+---
+
+## Task 7: Delete `docker/`, `k8s/`, and the eight k8s-era scripts
+
+**Goal:** Remove the microservices artifacts. Confirm by grep that no surviving file references them, then delete and re-verify the production build.
+
+**Files:**
+- Delete directory: `docker/`
+- Delete directory: `k8s/`
+- Delete: `scripts/deploy_pod_lifecycle.sh`, `scripts/generate_cronjobs.sh`, `scripts/calculate_cronjob_schedules.sh`, `scripts/activate_lifecycle.sh`, `scripts/emergency_rollback.sh`, `scripts/docker_build_all.sh`, `scripts/deploy-local.sh`, `scripts/status.sh`
+
+- [ ] **Step 1: Verify nothing surviving references `docker/`'s healthcheck scripts**
+
+```bash
+grep -rln "docker/healthcheck-league\|docker/healthcheck-shiny" RCode/ scripts/ tests/testthat/ Dockerfile docker-compose.yml docker-start.sh 2>/dev/null
+```
+
+Expected: no output.
+
+- [ ] **Step 2: Verify nothing surviving references `k8s/` paths from R or shell**
+
+```bash
+grep -rln "k8s/" RCode/ scripts/ tests/testthat/ Dockerfile docker-compose.yml docker-start.sh 2>/dev/null
+```
+
+Expected output: only `RCode/csv_generation.R` (the conditional `configmap-generator.R` block — handled in Task 9). If anything else appears, stop and investigate.
+
+- [ ] **Step 3: Verify nothing surviving sources the eight k8s-era scripts**
+
+```bash
+grep -rln "deploy_pod_lifecycle\|generate_cronjobs\|calculate_cronjob_schedules\|activate_lifecycle\|emergency_rollback\|docker_build_all\|deploy-local\|status\.sh" RCode/ scripts/season_transition.R scripts/install_test_packages.R Dockerfile docker-compose.yml docker-start.sh 2>/dev/null
+```
+
+Expected: no output. (We exclude the eight scripts themselves from the search by being explicit about what we *do* search.)
+
+- [ ] **Step 4: Delete the `docker/` directory**
+
+```bash
+git rm -r docker/
+```
+
+Expected output: `rm 'docker/healthcheck-league.R'`, `rm 'docker/healthcheck-shiny.R'`.
+
+- [ ] **Step 5: Delete the `k8s/` directory**
+
+```bash
+git rm -r k8s/
+```
+
+Expected output: many `rm` lines (manifests, cronjobs, configmaps, monitoring, rbac, scripts, templates).
+
+- [ ] **Step 6: Delete the eight k8s-era shell scripts**
+
+```bash
+git rm scripts/deploy_pod_lifecycle.sh scripts/generate_cronjobs.sh scripts/calculate_cronjob_schedules.sh scripts/activate_lifecycle.sh scripts/emergency_rollback.sh scripts/docker_build_all.sh scripts/deploy-local.sh scripts/status.sh
+```
+
+- [ ] **Step 7: Verify what's left in `scripts/`**
+
+```bash
+ls scripts/
+```
+
+Expected output (exactly):
+```
+install_test_packages.R
+season_transition.R
+```
+
+- [ ] **Step 8: Check for `RCode/test_scheduler_now.R`**
+
+This file appears to be a test utility for the dead `updateSchedulerSimple.R`. Read it to confirm:
+
+```bash
+head -10 RCode/test_scheduler_now.R
+```
+
+If it sources or references `updateSchedulerSimple` or `updateScheduler.R` (the old one) in a way that's no longer meaningful, delete it:
+
+```bash
+git rm RCode/test_scheduler_now.R
+```
+
+If you can't tell whether it's dead, leave it for a follow-up — do not delete on uncertainty.
+
+- [ ] **Step 9: Rebuild production image**
+
+```bash
+docker build -f Dockerfile -t league-simulator:after-deletes-2 .
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 10: Re-run the season-transition smoke check**
+
+```bash
+Rscript -e 'tryCatch(source("scripts/season_transition.R"), error = function(e) cat("ERROR:", e$message, "\n"))' 2>&1 | tee /tmp/season-transition-after-task-7.txt
+diff /tmp/season-transition-baseline.txt /tmp/season-transition-after-task-7.txt
+```
+
+Expected: same error as baseline; no meaningful diff.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add -A
+git commit -m "chore: delete docker/, k8s/, and k8s-era scripts/ helpers
+
+Removed:
+- docker/ (healthcheck scripts, only used by deleted Dockerfile.league/shiny)
+- k8s/ (microservices manifests, refactor e52f182 reverted in practice)
+- scripts/{deploy_pod_lifecycle,generate_cronjobs,calculate_cronjob_schedules,
+  activate_lifecycle,emergency_rollback,docker_build_all,deploy-local,status}.sh
+
+scripts/ now contains only install_test_packages.R and season_transition.R.
+Recovery available via tag pre-deployment-cleanup-2026-05-02. (issue #78)"
+```
+
+---
+
+## Task 8: Delete `RCode/configmap_deployment.R` and the orphan ConfigMap source block in `csv_generation.R`
+
+**Goal:** With `k8s/` gone, the optional `configmap-generator.R` source block in `csv_generation.R:79–109` can never find its target. Delete the block and the standalone `configmap_deployment.R` file. This is the only behavioral change in the entire plan, and it's a strict subtraction (one optional code path removed).
+
+**Files:**
+- Delete: `RCode/configmap_deployment.R`
+- Modify: `RCode/csv_generation.R` (remove lines 79–109, the `tryCatch` block)
+
+- [ ] **Step 1: Confirm `configmap_deployment.R` has no R callers**
+
+```bash
+grep -rln "configmap_deployment\|verify_configmap_deployment" RCode/ scripts/ tests/testthat/ 2>/dev/null
+```
+
+Expected output: only `RCode/configmap_deployment.R` itself (the file that defines the function). If `csv_generation.R` shows up here with a `verify_configmap_deployment` call, stop — there's a coupling we missed.
+
+- [ ] **Step 2: Confirm the `configmap-generator.R` source block is the only consumer of the `k8s/templates/` path inside `csv_generation.R`**
+
+```bash
+grep -n "configmap\|k8s/" RCode/csv_generation.R
+```
+
+Expected output (matches the PRD's identification of the block):
+```
+83:            "k8s/templates/configmap-generator.R",
+84:            file.path("..", "k8s", "templates", "configmap-generator.R"),
+85:            file.path("..", "..", "k8s", "templates", "configmap-generator.R"),
+86:            file.path(getwd(), "k8s", "templates", "configmap-generator.R")
+89:        configmap_generator_path <- NULL
+92:                configmap_generator_path <- path
+97:        if (!is.null(configmap_generator_path)) {
+98:            source(configmap_generator_path)
+99:            yaml_file <- generate_configmap_yaml(file_path, season, version = "1.0.0")
+100:            cat("✓ Generated ConfigMap YAML:", yaml_file, "\n")
+104:                cat("ConfigMap generator not found, skipping YAML generation\n")
+108:        cat("Warning: Could not generate ConfigMap YAML:", e$message, "\n")
+```
+
+- [ ] **Step 3: Read the surrounding context to find the precise extent of the block to remove**
+
+```bash
+sed -n '75,115p' RCode/csv_generation.R
+```
+
+The block starts at the line containing `# Generate corresponding ConfigMap YAML if ConfigMap generator is available` (around line 79) and ends at the closing `})` of the outer `tryCatch` (around line 109). Read these lines carefully so the next step removes exactly the right range.
+
+- [ ] **Step 4: Remove the ConfigMap block from `csv_generation.R`**
+
+Use the Edit tool (not `sed`, since the block contains parentheses and special characters that are easy to miscount). Find this exact block in `RCode/csv_generation.R`:
+
+```r
+    # Generate corresponding ConfigMap YAML if ConfigMap generator is available
+    tryCatch({
+        # Try multiple paths for the configmap generator
+        possible_paths <- c(
+            "k8s/templates/configmap-generator.R",
+            file.path("..", "k8s", "templates", "configmap-generator.R"),
+            file.path("..", "..", "k8s", "templates", "configmap-generator.R"),
+            file.path(getwd(), "k8s", "templates", "configmap-generator.R")
+        )
+        
+        configmap_generator_path <- NULL
+        for (path in possible_paths) {
+            if (file.exists(path)) {
+                configmap_generator_path <- path
+                break
+            }
+        }
+        
+        if (!is.null(configmap_generator_path)) {
+            source(configmap_generator_path)
+            yaml_file <- generate_configmap_yaml(file_path, season, version = "1.0.0")
+            cat("✓ Generated ConfigMap YAML:", yaml_file, "\n")
+        } else {
+            # This is not an error - ConfigMap generation is optional
+            if (interactive() || getOption("verbose", FALSE)) {
+                cat("ConfigMap generator not found, skipping YAML generation\n")
+            }
+        }
+    }, error = function(e) {
+        cat("Warning: Could not generate ConfigMap YAML:", e$message, "\n")
+    })
+    
+```
+
+Replace it with nothing (delete the block, including the trailing blank line). The surrounding lines (the `cat("Team list CSV created successfully:", ...)` block above and the `return(file_path)` below) stay unchanged.
+
+- [ ] **Step 5: Verify the block is gone**
+
+```bash
+grep -n "configmap\|k8s/" RCode/csv_generation.R
+```
+
+Expected: no output.
+
+- [ ] **Step 6: Verify R can still parse the modified file**
+
+```bash
+Rscript -e 'parse("RCode/csv_generation.R"); cat("OK\n")'
+```
+
+Expected: `OK`.
+
+- [ ] **Step 7: Delete `RCode/configmap_deployment.R`**
+
+```bash
+git rm RCode/configmap_deployment.R
+```
+
+- [ ] **Step 8: Re-run the season-transition smoke check (this task touched a season-transition module)**
+
+```bash
+Rscript -e 'tryCatch(source("scripts/season_transition.R"), error = function(e) cat("ERROR:", e$message, "\n"))' 2>&1 | tee /tmp/season-transition-after-task-8.txt
+diff /tmp/season-transition-baseline.txt /tmp/season-transition-after-task-8.txt
+```
+
+Expected: same error as baseline; no meaningful diff. **This is the critical canary** — `csv_generation.R` is part of the season-transition workflow, and we just edited it.
+
+- [ ] **Step 9: Rebuild the Docker image**
+
+```bash
+docker build -f Dockerfile -t league-simulator:after-deletes-3 .
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add RCode/csv_generation.R RCode/configmap_deployment.R
+git commit -m "chore: remove orphan ConfigMap generation from csv_generation.R
+
+Deleted RCode/configmap_deployment.R and the optional tryCatch block in
+RCode/csv_generation.R that conditionally sourced
+k8s/templates/configmap-generator.R. With k8s/ deleted, the path could
+never be found and the block was strictly dead weight.
+
+Season-transition smoke check still passes. (issue #78)"
+```
+
+---
+
+## Task 9: Update `CLAUDE.md` to remove dead Dockerfile references and fix the Simple Deployment pointer
+
+**Goal:** `CLAUDE.md` has three lines that reference deleted files: lines 19 and 20 in the Quick Commands block (`Dockerfile.simple`, `docker-compose.simple.yml`) and line 70 (the Simple Deployment doc pointer). Update all three.
+
+**Files:**
+- Modify: `CLAUDE.md` (lines 19, 20, and 70)
+
+- [ ] **Step 1: Inspect the current state**
+
+```bash
+grep -n "Dockerfile\.simple\|docker-compose\.simple\|Simple Deployment\|simple-monolithic" CLAUDE.md
+```
+
+Expected output (three lines):
+```
+19:docker build -f Dockerfile.simple -t league-simulator:simple .
+20:docker-compose -f docker-compose.simple.yml up -d
+70:  - **Simple Deployment** (Recommended): @docs/deployment/simple-monolithic.md
+```
+
+- [ ] **Step 2: Update the Quick Commands block (lines 19–20)**
+
+Use the Edit tool to find this exact text in `CLAUDE.md`:
+
+```markdown
+# Build and run Docker (simple version)
+docker build -f Dockerfile.simple -t league-simulator:simple .
+docker-compose -f docker-compose.simple.yml up -d
+```
+
+Replace with:
+
+```markdown
+# Build and run the production Docker stack
+docker build -t league-simulator:latest .
+docker-compose up -d
+```
+
+(Drops `-f` flags since `Dockerfile` and `docker-compose.yml` are now the defaults.)
+
+- [ ] **Step 3: Update the Simple Deployment pointer (line 70)**
+
+Find this exact text in `CLAUDE.md`:
+
+```markdown
+  - **Simple Deployment** (Recommended): @docs/deployment/simple-monolithic.md
+```
+
+Replace with:
+
+```markdown
+  - **Production Deployment**: @docs/deployment/README.md
+```
+
+- [ ] **Step 4: Verify all three references are gone**
+
+```bash
+grep -n "Dockerfile\.simple\|docker-compose\.simple\|Simple Deployment\|simple-monolithic" CLAUDE.md
+```
+
+Expected: no output.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: update CLAUDE.md to reference renamed Dockerfile and new README
+
+Replaced:
+- Dockerfile.simple / docker-compose.simple.yml -> default Dockerfile / docker-compose.yml
+- 'Simple Deployment (Recommended)' pointer -> 'Production Deployment' pointing to docs/deployment/README.md (created in next task)
+
+(issue #78)"
+```
+
+---
+
+## Task 10: Replace `docs/deployment/simple-monolithic.md` with a new `docs/deployment/README.md`
+
+**Goal:** Delete the misleading `simple-monolithic.md` (which described the now-deleted simple stack as "Recommended") and write a new `docs/deployment/README.md` that documents the actual production stack.
+
+**Files:**
+- Delete: `docs/deployment/simple-monolithic.md`
+- Create: `docs/deployment/README.md`
+
+- [ ] **Step 1: Delete the misleading doc**
+
+```bash
+git rm docs/deployment/simple-monolithic.md
+```
+
+- [ ] **Step 2: Create the new operator README**
+
+Create `docs/deployment/README.md` with this exact content:
+
+````markdown
+# Deployment
+
+The League Simulator runs as a single Docker container that combines the Rust simulation engine and the R scheduler. This is the only production deployment path.
+
+## Stack
+
+- **`Dockerfile`** — multi-stage build: Rust 1.81 (alpine) compiles the simulation binary in stage 1; `rocker/r-ver:4.3.1` runs the R scheduler in stage 2.
+- **`docker-compose.yml`** — single service `league-simulator-integrated`, exposes port 8081 → container port 8080 (Rust API for monitoring).
+- **`docker-start.sh`** — container entrypoint. Starts the Rust server on `localhost:8080`, waits for it to be healthy, then runs `Rscript RCode/updateScheduler.R` with retry logic.
+- **`RCode/updateScheduler.R`** — the R scheduler. Wakes at 14:45 Berlin time, polls api-football, calls the in-process Rust server when new fixtures arrive, pushes results to ShinyApps.io.
+
+## Schedule
+
+- **Active hours:** 14:45 – 22:45 Berlin time (`updateScheduler.R` enforces both bounds).
+- **Loop frequency:** every 2 minutes inside the active window (Rust engine is fast enough to allow this).
+- **Outside the window:** the scheduler sleeps until the next 14:45.
+
+## Required environment variables
+
+| Variable | Required | Default | Purpose |
+|---|---|---|---|
+| `RAPIDAPI_KEY` | yes | — | api-football access via RapidAPI |
+| `SHINYAPPS_IO_SECRET` | yes | — | ShinyApps.io deployment auth |
+| `SHINYAPPS_IO_NAME` | no | `chrisschwer` | ShinyApps.io account name |
+| `SHINYAPPS_IO_TOKEN` | no | (set in compose) | ShinyApps.io token |
+| `SEASON` | no | auto-detect | Season year (e.g., `2025`); auto-detects from current month if unset |
+| `DURATION` | no | `480` | Cap on scheduler runtime in minutes |
+| `RUST_API_URL` | no | `http://localhost:8080` | Rust server endpoint inside the container |
+| `TZ` | no | `Europe/Berlin` | Container timezone |
+
+## Build and run
+
+```bash
+# Build
+docker build -t league-simulator:latest .
+
+# Run via docker-compose (recommended)
+docker-compose up -d
+
+# Inspect logs
+docker-compose logs -f league-simulator-integrated
+
+# Stop
+docker-compose down
+```
+
+## Health check
+
+The container exposes `http://localhost:8081/health` (the Rust server's health endpoint). Docker's `HEALTHCHECK` directive in the Dockerfile polls this every 30 seconds.
+
+## Recovery
+
+If you need to compare against the pre-cleanup deployment surface (which had multiple Dockerfiles, a `k8s/` directory, and several scheduler variants), check out the annotated tag:
+
+```bash
+git checkout pre-deployment-cleanup-2026-05-02
+```
+
+That tag captures the full pre-cleanup tree.
+
+## Operator-side workflows (not covered here)
+
+The season-transition workflow is a separate, locally-invoked operator procedure that runs **before** a container rebuild to produce fresh `RCode/TeamList_<year>.csv` files. It does not run inside the production container.
+
+- **Operator guide:** [`docs/user-guide/season-transition.md`](../user-guide/season-transition.md)
+- **Recent changes:** [`docs/SEASON_TRANSITION_UPDATES.md`](../SEASON_TRANSITION_UPDATES.md)
+- **Discoverability for validation/report/cleanup helpers:** GitHub issue #74
+````
+
+- [ ] **Step 3: Sanity-check the new README**
+
+```bash
+test -f docs/deployment/README.md && echo "OK" || echo "MISSING"
+wc -l docs/deployment/README.md
+```
+
+Expected: `OK`, ~70 lines.
+
+- [ ] **Step 4: Verify `CLAUDE.md`'s pointer (set in Task 9) resolves**
+
+```bash
+grep "docs/deployment/README.md" CLAUDE.md
+```
+
+Expected: at least one match.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/deployment/simple-monolithic.md docs/deployment/README.md
+git commit -m "docs: replace simple-monolithic.md with deployment/README.md
+
+The old doc described a stack (Dockerfile.simple + docker-compose.simple.yml)
+that was deleted in this PRD. The new README documents the actual production
+stack (single Dockerfile + docker-compose.yml + docker-start.sh +
+RCode/updateScheduler.R) and points operators to the season-transition
+workflow docs. (issue #78)"
+```
+
+---
+
+## Task 11: Footnote the microservices section in `docs/architecture/overview.md`
+
+**Goal:** The architecture overview has a "Microservices Migration" section (line 332) describing the now-deleted microservices design as the future direction. Mark it as historical context, not roadmap, so future readers don't reintroduce the complexity.
+
+**Files:**
+- Modify: `docs/architecture/overview.md` (insert a note before the "Microservices Migration" subsection at line 332)
+
+- [ ] **Step 1: Inspect the current section header and surrounding context**
+
+```bash
+sed -n '328,345p' docs/architecture/overview.md
+```
+
+Expected: shows the section heading `### Microservices Migration` near line 332 inside a larger "Future Architecture Considerations" or similar parent section.
+
+- [ ] **Step 2: Insert a historical-context note immediately after the section heading**
+
+Use the Edit tool. Find this exact text in `docs/architecture/overview.md`:
+
+```markdown
+### Microservices Migration
+```
+
+Replace with:
+
+```markdown
+### Microservices Migration
+
+> **Historical context (2026-05-02):** A microservices split was attempted (see git tag `pre-deployment-cleanup-2026-05-02` for the full multi-Dockerfile + `k8s/` tree) and reverted in favor of a single integrated container that runs the Rust simulation engine and the R scheduler in one process group. The diagram below documents the rejected design; it is **not** the current or planned architecture. See `docs/deployment/README.md` for what's actually deployed.
+```
+
+- [ ] **Step 3: Verify the note landed**
+
+```bash
+grep -A1 "Historical context (2026-05-02)" docs/architecture/overview.md | head -3
+```
+
+Expected: shows the note text.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/architecture/overview.md
+git commit -m "docs: footnote microservices section as historical, not roadmap
+
+The 'Microservices Migration' section described a design that was
+attempted and reverted. Mark it explicitly so future readers don't
+mistake it for the current direction. (issue #78)"
+```
+
+---
+
+## Task 12: Run the acceptance grep and final smoke tests
+
+**Goal:** Verify the PRD's acceptance criteria pass against the cleaned-up tree (within the source-code scope this plan committed to). Build the final image, compare against the pre-cleanup baseline, and confirm everything is green.
+
+**Files:**
+- No file changes. This task is verification-only.
+
+- [ ] **Step 1: Run the source-code-scoped legacy-name grep**
+
+```bash
+grep -rEn "Dockerfile\.(simple|league|shiny|optimized|integrated|test)|docker-compose\.(simple|integrated)|updateSchedulerRust|updateSchedulerSimple|update_all_leagues_loop_rust|docker-integrated-start|configmap_deployment|configmap-generator" RCode/ scripts/ tests/testthat/ Dockerfile docker-compose.yml docker-start.sh CLAUDE.md docs/deployment/README.md 2>/dev/null
+```
+
+Expected: **no output**. If any line appears, it identifies a stale reference inside the source-code scope; fix before continuing.
+
+- [ ] **Step 2: Run the survivor-list grep**
+
+```bash
+grep -rEn "season_validation|elo_aggregation|api_service|api_helpers|interactive_prompts|input_validation|csv_generation|file_operations|season_processor|league_processor|error_handling|input_handler|team_config_loader|team_data_carryover|SpielCPP" scripts/season_transition.R | head -20
+```
+
+Expected: shows ~18 lines (`source()` and `safe_source()` calls in `scripts/season_transition.R`) — the season-transition modules are still there and still referenced. If this comes back empty, the survivor list has been broken and we have a regression.
+
+- [ ] **Step 3: Build the post-cleanup image**
+
+```bash
+docker build -f Dockerfile -t league-simulator:post-cleanup .
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 4: Compare image layer counts**
+
+```bash
+PRE=$(docker history --no-trunc --format '{{.ID}}' league-simulator:pre-cleanup | wc -l)
+POST=$(docker history --no-trunc --format '{{.ID}}' league-simulator:post-cleanup | wc -l)
+echo "Pre-cleanup layers: $PRE"
+echo "Post-cleanup layers: $POST"
+```
+
+Expected: identical (or off by ≤1 if one of the renames changed cache-key boundaries). The build steps are byte-identical apart from the renamed `COPY docker-start.sh` line.
+
+- [ ] **Step 5: `docker-compose config` final check**
+
+```bash
+docker-compose config > /dev/null && echo "compose OK"
+```
+
+Expected: `compose OK`.
+
+- [ ] **Step 6: Final season-transition smoke check**
+
+```bash
+Rscript -e 'tryCatch(source("scripts/season_transition.R"), error = function(e) cat("ERROR:", e$message, "\n"))' 2>&1 | tee /tmp/season-transition-final.txt
+diff /tmp/season-transition-baseline.txt /tmp/season-transition-final.txt
+```
+
+Expected: same baseline error; no meaningful diff.
+
+- [ ] **Step 7: Show the final repo-root and `RCode/` Dockerfile/scheduler shape**
+
+```bash
+ls -1 | grep -i "^dockerfile\|^docker-compose\|^docker-start"
+echo '---'
+ls RCode/updateScheduler*.R RCode/update_all_leagues_loop*.R RCode/configmap_deployment.R 2>&1
+echo '---'
+ls scripts/
+```
+
+Expected:
+```
+docker-compose.yml
+docker-start.sh
+Dockerfile
+---
+RCode/updateScheduler.R
+RCode/update_all_leagues_loop.R
+ls: RCode/configmap_deployment.R: No such file or directory
+---
+install_test_packages.R
+season_transition.R
+```
+
+- [ ] **Step 8: Show `git log` of the cleanup commits for the record**
+
+```bash
+git log --oneline pre-deployment-cleanup-2026-05-02..HEAD
+```
+
+Expected: 10 commits (Tasks 2 through 11; Task 1 made no commit, Task 12 makes none).
+
+- [ ] **Step 9: No commit needed**
+
+This task only ran checks. If everything is green, the plan is complete and ready to merge to `main` (or push to a feature branch and open a PR, per your normal workflow).
+
+---
+
+## Acceptance Criteria Mapping (PRD ↔ Plan)
+
+This is the self-review check the writing-plans skill requires. Each PRD acceptance criterion maps to one or more tasks:
+
+| PRD Acceptance Criterion | Implementing Task(s) |
+|---|---|
+| Annotated tag `pre-deployment-cleanup-2026-05-02` exists | Task 1, Steps 3–5 |
+| Repo root has exactly one Dockerfile, one compose, one start script | Tasks 2, 3, 5 (renames) + Task 6, Step 5 (verification) |
+| `RCode/` has exactly one scheduler and one loop | Task 4 (renames overwrite duplicates) + Task 6, Step 6 (verification) |
+| `docker/` and `k8s/` no longer exist | Task 7, Steps 4–5 |
+| All k8s-era helpers in `scripts/` no longer exist | Task 7, Step 6 + Step 7 (verification) |
+| `docker build -f Dockerfile -t league-simulator:test .` succeeds | Tasks 2, 3, 4, 6, 7, 8, 12 (all rebuild after each change) |
+| `docker-compose config` parses cleanly | Task 5, Step 4 + Task 12, Step 5 |
+| Source-code-scoped legacy-name grep returns zero matches | Task 12, Step 1 |
+| `simple-monolithic.md` deleted; new `README.md` documents the stack | Task 10 |
+| `CLAUDE.md` Simple Deployment pointer replaced | Task 9 |
+| `docs/architecture/overview.md` microservices section footnoted | Task 11 |
+| Season-transition smoke test passes after cleanup | Task 6, Step 8; Task 7, Step 10; Task 8, Step 8; Task 12, Step 6 |
+| `RCode/configmap_deployment.R` deleted; `csv_generation.R` block removed | Task 8 |
+
+**Out-of-plan-scope (per Option 1 decision):** Doc cleanup across `docs/deployment/{detailed-guide,local-development,production,rollback,simplified-microservices,quick-start,ci-cd-guide}.md`, `tests/REVISED_TEST_SPECIFICATIONS.md`, `tests/container-league.yaml`, `tests/docker/`, `RUST_INTEGRATION.md`, `PRD_ISSUE_1_monolithic_deployment.md`, `.claude/development_workflow.md`, `.claude/testing_and_build.md`. A separate GitHub issue tracks this.
+
+## Self-Review Notes
+
+Performed before publishing:
+
+1. **Spec coverage:** All 12 PRD acceptance criteria map to a concrete task and step. The PRD's 8-step migration plan corresponds to Tasks 1–11 (split for granularity). The PRD's "Files that must survive" subsection drives the survivor-list grep in Task 12, Step 2.
+
+2. **Placeholder scan:** No `TBD`, `TODO`, `implement later`, or `add appropriate X` placeholders. Every code block is the literal text the engineer should produce. The one judgment call (Task 7 Step 8: whether to delete `RCode/test_scheduler_now.R`) is explicit about its uncertainty.
+
+3. **Type / name consistency:** The renamed function is `update_all_leagues_loop` (no qualifier) in both its definition (Task 4 Step 5) and its call site (Task 4 Step 4). The renamed scheduler is `updateScheduler.R` everywhere. The renamed start script is `docker-start.sh` everywhere. The new doc is `docs/deployment/README.md` everywhere.

--- a/docs/superpowers/plans/2026-05-02-simulation-engine-seam.md
+++ b/docs/superpowers/plans/2026-05-02-simulation-engine-seam.md
@@ -1,0 +1,1089 @@
+# Retire C++ engine fallback in production loop (Phase 1) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `leagueSimulatorRust()` the only simulation entry point invoked by the production loop. Remove the duplicated fallback wiring (loop-level `if (use_rust)`, the per-call check inside `leagueSimulatorRust`, the `use_rust` parameter, the brittle `Rcpp::sourceCpp` build step in the Dockerfile). When the Rust server is unavailable, the scheduler fails fast with a clear error referencing `RUST_API_URL`. **Phase 1 keeps all C++ source files in `RCode/`** because `scripts/season_transition.R:65` sources `SpielCPP.R` — Phase 2 (a future, separately-derived plan) decides their long-term fate.
+
+**Architecture:** Three small touch-points, all in already-renamed files (the deployment-collapse PRD #78 has landed): (1) `RCode/update_all_leagues_loop.R` loses its `if (use_rust) { ... } if (!use_rust) { source CPP ... }` block (lines 26–45), drops the `use_rust` parameter, and inlines `simulator_function`; (2) `RCode/rust_integration.R` loses the per-call CPP fallback inside `leagueSimulatorRust()` (lines 150–156); (3) `RCode/updateScheduler.R` upgrades its warning at line 155–158 to a `stop()` and drops the `use_rust = rust_available` argument at line 172. The `Dockerfile` loses lines 101–104 (the runtime `Rcpp::sourceCpp('SpielNichtSimulieren.cpp')` step) since its only consumer was the deleted fallback. C++ source files in `RCode/` are not touched.
+
+**Tech Stack:** R 4.3.1, `httr` + `jsonlite` for the Rust REST client, the existing Rust crate at `league-simulator-rust/`, Docker. testthat 3.x for the regression test. No new dependencies.
+
+**Reference:** PRD at `docs/prds/2026-05-02-simulation-engine-seam.md` (also GitHub issue #77). Companion deployment-collapse PRD #78 has been merged to `main` (recovery tag `pre-deployment-cleanup-2026-05-02`).
+
+**Survivor list — DO NOT TOUCH:** `RCode/leagueSimulatorCPP.R`, `RCode/simulationsCPP.R`, `RCode/SaisonSimulierenCPP.R`, `RCode/SpielCPP.R`, `RCode/SpielNichtSimulieren.cpp`, `RCode/cpp_wrappers.R`, `RCode/RcppExports.R`, the entire `tests/testthat/test-*CPP*.R` family, `tests/rust/test_rust_vs_cpp_detailed.R`, `compare_rust_cpp.R`, `compare_rust_vs_r.R`, `scripts/season_transition.R` and its 18 dependencies. Phase 2 decides the long-term fate of these.
+
+---
+
+## File Inventory
+
+### Files modified (4)
+
+| File | Change |
+|---|---|
+| `RCode/update_all_leagues_loop.R` | Replace lines 4 + 26–45 + 104 + the `if (use_rust)` echoes in 109/117/125 + 150–152; drop `use_rust` parameter |
+| `RCode/rust_integration.R` | Delete lines 150–156 (per-call CPP fallback inside `leagueSimulatorRust`) |
+| `RCode/updateScheduler.R` | Replace lines 155–158 (warning → `stop()`); remove `use_rust = rust_available` at line 172 |
+| `Dockerfile` | Delete lines 101–104 (the `Rcpp::sourceCpp` runtime build step) |
+
+### Files created (1)
+
+- `tests/testthat/test-rust-required.R` — the regression net (positive + negative cases for the new fail-fast behavior)
+
+### Files NOT touched (Phase 1 boundary)
+
+C++ engine sources, all CPP testthat files, comparison harnesses, season-transition workflow, `packagelist.txt` (Rcpp stays), `DESCRIPTION` (Rcpp linkage stays). Documentation (`docs/architecture/overview.md`, `RUST_INTEGRATION.md`, etc.) is also out of scope — issue #79 sweeps those.
+
+### Out-of-plan-scope (deferred to Phase 2)
+
+Deletion of C++ engine files, Rcpp removal from `packagelist.txt`/`DESCRIPTION`, deletion of CPP testthat files and comparison harnesses, season-transition migration to the Rust seam (or formal blessing of CPP as season-transition's tool).
+
+---
+
+## Task 1: Pre-flight verification + worktree baseline
+
+**Goal:** Confirm clean baseline, capture the current production image as a regression target, and confirm the Rust binary can be built and started locally (the new test depends on it). No commits.
+
+**Files:** None modified.
+
+- [ ] **Step 1: Confirm clean working tree on the worktree branch**
+
+```bash
+git status --short
+git branch --show-current
+```
+
+Expected: empty status; branch name matches the worktree's feature branch (will be set up by `superpowers:using-git-worktrees` before this plan starts — typical name `feature/issue-77-rust-seam`).
+
+- [ ] **Step 2: Confirm post-#78 production state is intact**
+
+```bash
+ls Dockerfile docker-compose.yml docker-start.sh RCode/updateScheduler.R RCode/update_all_leagues_loop.R RCode/rust_integration.R 2>&1
+```
+
+Expected: all 6 files listed cleanly. If any are missing, the worktree is in the wrong state — STOP and ask.
+
+- [ ] **Step 3: Confirm the C++ survivors are present (we must NOT delete these in Phase 1)**
+
+```bash
+ls RCode/leagueSimulatorCPP.R RCode/simulationsCPP.R RCode/SaisonSimulierenCPP.R RCode/SpielCPP.R RCode/SpielNichtSimulieren.cpp RCode/cpp_wrappers.R RCode/RcppExports.R
+```
+
+Expected: all 7 files present.
+
+- [ ] **Step 4: Build the current production image as a regression baseline**
+
+Use the nohup pattern (lesson from PRD #78's Task 1 — Docker builds get killed by wrapper exits):
+
+```bash
+cd <worktree-absolute-path>
+nohup docker build -f Dockerfile -t league-simulator:phase1-pre . > /tmp/docker-build-phase1-pre.log 2>&1 & disown
+echo "PID: $!"
+```
+
+Poll `tail /tmp/docker-build-phase1-pre.log` until `Successfully tagged league-simulator:phase1-pre` or an error. Heavy cache hit expected (the image is identical to whatever was last built on `main`); should complete in ~10–60 seconds.
+
+If the build fails: STOP and report BLOCKED. The production image is broken in a way unrelated to this plan.
+
+- [ ] **Step 5: Capture the baseline image ID**
+
+```bash
+docker images league-simulator:phase1-pre --format '{{.ID}}'
+```
+
+Record the ID. Task 7's verification compares against it.
+
+- [ ] **Step 6: Build the Rust binary natively (the new test needs it)**
+
+```bash
+cd league-simulator-rust
+nohup cargo build --release > /tmp/cargo-build-phase1.log 2>&1 & disown
+echo "PID: $!"
+```
+
+Poll `tail /tmp/cargo-build-phase1.log`. First-time build can take 2–5 minutes (downloads + compiles dependencies). Subsequent invocations of this plan in the same worktree will be near-instant.
+
+If `cargo build` fails: STOP and report BLOCKED — without a local Rust binary, the new test cannot run (Phase 1 cannot land without its regression net).
+
+Confirm the binary exists:
+
+```bash
+ls -la league-simulator-rust/target/release/league-simulator-rust
+```
+
+Expected: an executable file ~5–20 MB.
+
+- [ ] **Step 7: Smoke-test the Rust server starts and reports health**
+
+```bash
+league-simulator-rust/target/release/league-simulator-rust --api &
+RUST_PID=$!
+sleep 3
+curl -sf http://localhost:8080/health && echo "OK"
+kill $RUST_PID 2>/dev/null
+wait $RUST_PID 2>/dev/null
+```
+
+Expected: `OK` printed (after the curl response). Confirms the binary speaks the contract the plan's tests will rely on.
+
+If `curl` errors: report BLOCKED with the curl output and the Rust server's stderr.
+
+- [ ] **Step 8: Capture the season-transition baseline (canary for Task 6)**
+
+```bash
+Rscript -e 'tryCatch(source("scripts/season_transition.R"), error = function(e) cat("EXPECTED ARGS-MISSING ERROR:", e$message, "\n"))' 2>&1 | tee /tmp/season-transition-baseline-phase1.txt
+```
+
+Expected: the script sources its 18 modules (15 transition-specific + `retrieveResults.R`, `transform_data.R`, `SpielCPP.R`), then fails on missing args. The output file lives at `/tmp/season-transition-baseline-phase1.txt` for Task 6's diff.
+
+If sourcing fails before reaching the args-error (e.g., Rcpp not configured locally for `SpielCPP.R`): record the failure pattern. The downstream canary will compare against whatever this baseline is — including a baseline of "Rcpp not configured" — so as long as the post-Phase-1 output matches it, we have proof the changes didn't regress anything.
+
+- [ ] **Step 9: No commit**
+
+Task 1 makes no working-tree changes.
+
+---
+
+## Task 2: Add the regression test (TDD red)
+
+**Goal:** Add `tests/testthat/test-rust-required.R` with both the positive-path and negative-path tests, run them against the **current** code, and confirm: positive passes, negative *fails as expected* (because today's code silently falls back to CPP when Rust is down — the test will assert `stop()` which the current code doesn't do).
+
+The test fixture starts the Rust binary in a `setup`/`teardown`, calls a single iteration of `update_all_leagues_loop()` with a tiny input, and asserts on the result shape.
+
+**Files:**
+- Create: `tests/testthat/test-rust-required.R`
+- Create: `tests/testthat/fixtures/rust-required/TeamList_minimal.csv` (small 4-team fixture)
+
+- [ ] **Step 1: Inspect existing test infrastructure for conventions**
+
+```bash
+ls tests/testthat/helper-*.R tests/testthat/fixtures/ 2>&1
+head -15 tests/testthat/helper-test-setup.R 2>/dev/null
+```
+
+The repo has `tests/testthat/helper-test-setup.R` and `tests/testthat/helper-deployment.R`. The new test does not need to extend them — it's self-contained. The `fixtures/` subdirectory exists; we'll add a `rust-required/` subdir there.
+
+- [ ] **Step 2: Create the minimal team-list fixture**
+
+Create `tests/testthat/fixtures/rust-required/TeamList_minimal.csv` with this exact content (4 teams, semicolon-separated to match the production CSV format from `read.csv(TeamList_file, sep=";")` at `update_all_leagues_loop.R:55`):
+
+```csv
+TeamID;ShortName;Promotion;InitialELO
+1;TST;0;1500
+2;UAA;0;1500
+3;UBB;0;1500
+4;UCC;0;1500
+```
+
+Real `TeamList_*.csv` files have more columns (verified from `RCode/TeamList_2025.csv`); this fixture matches the *minimum* the loop needs to construct a valid season. If the loop errors during the test on missing columns, expand the fixture; do not change the loop.
+
+- [ ] **Step 3: Write the test file (RED — assertions are aspirational, will fail today on the negative case)**
+
+Create `tests/testthat/test-rust-required.R` with this exact content:
+
+```r
+# Phase 1 regression net for the Rust-required production loop.
+# Issue #77 / docs/superpowers/plans/2026-05-02-simulation-engine-seam.md.
+
+library(testthat)
+
+# --- Helpers: start/stop the Rust API server in the background ---
+
+rust_binary <- function() {
+  bin <- file.path("..", "..", "league-simulator-rust", "target", "release", "league-simulator-rust")
+  if (!file.exists(bin)) {
+    skip(sprintf("Rust binary not built at %s; run `cargo build --release` in league-simulator-rust/", bin))
+  }
+  normalizePath(bin)
+}
+
+start_rust_server <- function(port = 18080L) {
+  bin <- rust_binary()
+  log <- tempfile(fileext = ".log")
+  # Pass PORT via the parent environment. sys::exec_background (>= 3.4) inherits
+  # env from the caller and has no env= parameter; save/restore protects the
+  # parent's PORT if any.
+  old_port <- Sys.getenv("PORT", unset = NA)
+  Sys.setenv(PORT = as.character(port))
+  pid <- sys::exec_background(bin, args = "--api", std_out = log, std_err = log)
+  if (is.na(old_port)) Sys.unsetenv("PORT") else Sys.setenv(PORT = old_port)
+  Sys.setenv(RUST_API_URL = sprintf("http://localhost:%d", port))
+  # Wait up to 10 s for the server to become healthy.
+  ok <- FALSE
+  for (i in 1:50) {
+    Sys.sleep(0.2)
+    res <- tryCatch(httr::GET(paste0(Sys.getenv("RUST_API_URL"), "/health"),
+                              httr::timeout(0.5)),
+                    error = function(e) NULL)
+    if (!is.null(res) && httr::status_code(res) == 200) { ok <- TRUE; break }
+  }
+  list(pid = pid, log = log, ok = ok, port = port)
+}
+
+stop_rust_server <- function(handle) {
+  if (!is.null(handle$pid)) {
+    try(tools::pskill(handle$pid), silent = TRUE)
+  }
+}
+
+# Source the production loop fresh so the test sees the current state of the code.
+# The loop's source() calls inside its body assume cwd = repo root; we set it explicitly.
+with_repo_root <- function(expr) {
+  old <- getwd()
+  on.exit(setwd(old), add = TRUE)
+  setwd(file.path(old, "..", ".."))   # tests/testthat -> repo root
+  force(expr)
+}
+
+# --- Tests ---
+
+context("Phase 1 — Rust required, no fallback")
+
+test_that("update_all_leagues_loop runs one iteration end-to-end with Rust up", {
+  skip_if_not_installed("sys")
+  skip_if_not_installed("httr")
+  skip_if_not_installed("jsonlite")
+
+  handle <- start_rust_server()
+  on.exit(stop_rust_server(handle), add = TRUE)
+  if (!handle$ok) {
+    skip(sprintf("Rust server failed to come up on port %d; log: %s",
+                 handle$port, handle$log))
+  }
+
+  # Pre-set the FT counters so the loop's "first iteration" branch runs cleanly.
+  FT_BL <- 0; FT_BL2 <- 0; FT_Liga3 <- 0
+
+  with_repo_root({
+    source("RCode/update_all_leagues_loop.R", local = FALSE)
+    # The function exists post-source; just assert it can be invoked with a
+    # one-loop call and that we don't get an immediate error from sourcing/wiring.
+    # We don't assert on Ergebnis values here — we'd need a stubbed retrieveResults
+    # to do that, and that's a bigger fixture than this test should own. The
+    # post-refactor version of this test (Task 7) will exercise the seam shape.
+    expect_true(exists("update_all_leagues_loop"))
+    # Function signature check: in Phase 1's pre-state, has `use_rust` parameter;
+    # in Phase 1's post-state, does not. We assert nothing here — Task 7 does the
+    # signature check after the refactor.
+  })
+})
+
+test_that("loop fails fast with RUST_API_URL message when Rust is down (post-refactor)", {
+  skip_if_not_installed("httr")
+
+  # Point at a port that is guaranteed to refuse connections (no server here).
+  Sys.setenv(RUST_API_URL = "http://127.0.0.1:1")
+
+  with_repo_root({
+    source("RCode/update_all_leagues_loop.R", local = FALSE)
+    # PRE-REFACTOR EXPECTATION (will FAIL today, by design — this is the canary
+    # the refactor is meant to flip):
+    err <- tryCatch(
+      update_all_leagues_loop(duration = 0, loops = 1, n = 10,
+                              saison = "2024",
+                              TeamList_file = "tests/testthat/fixtures/rust-required/TeamList_minimal.csv",
+                              shiny_directory = tempdir()),
+      error = function(e) e
+    )
+    # Post-refactor: error message must mention "Rust simulator not available"
+    # and include the unreachable URL the test pointed at (http://127.0.0.1:1).
+    # Pre-refactor: today's code logs a warning and silently sources C++ (no error).
+    # So this assertion intentionally fails until Tasks 3–5 land.
+    expect_s3_class(err, "error")
+    expect_match(conditionMessage(err), "Rust simulator not available", fixed = TRUE)
+    expect_match(conditionMessage(err), "127.0.0.1:1", fixed = TRUE)
+  })
+})
+```
+
+**Notes on the test design:**
+- The positive test deliberately does NOT exercise the API-call path (`retrieveResults` would hit api-football and need an API key). It just confirms the loop file sources cleanly and the function exists. The post-refactor verification (Task 7) checks the seam shape via grep, not via end-to-end execution.
+- The negative test is the actual canary: it asserts the *post-refactor* contract (fail fast with `RUST_API_URL` in the message). Today, the same code silently warns and falls through to the CPP path — so this test FAILS today. That failure is the "RED" half of the TDD cycle. Tasks 3–5 turn it green.
+- `sys::exec_background` is the simplest way to launch a child process in R without blocking. The package is on CRAN; if it's not installed in the test environment, the test skips with a message.
+
+- [ ] **Step 4: Run the test against the current (pre-refactor) code**
+
+```bash
+Rscript -e 'testthat::test_file("tests/testthat/test-rust-required.R", reporter = "summary")'
+```
+
+Expected output (paraphrased):
+- First test (`update_all_leagues_loop runs one iteration ... with Rust up`): **PASS** if the Rust server came up; SKIP otherwise.
+- Second test (`loop fails fast with RUST_API_URL message`): **FAIL** with a message about `expect_s3_class(err, "error")` failing — because today's code returns `NULL` instead of erroring (or errors with a different message about something else). This failure is the documented red.
+
+If the second test PASSES today, that means the current code already fails fast — which would be surprising and worth investigating. STOP and report.
+
+If `sys` is not installed, install it: `Rscript -e 'install.packages("sys", repos = "https://cloud.r-project.org")'` and re-run.
+
+- [ ] **Step 5: Commit the test (RED state)**
+
+```bash
+git add tests/testthat/test-rust-required.R tests/testthat/fixtures/rust-required/TeamList_minimal.csv
+git commit -m "test: add Rust-required regression net for production loop (RED)
+
+Phase 1 of issue #77 fail-fast refactor. The negative test asserts the
+post-refactor contract: when Rust is unreachable, the loop must stop()
+with a message containing RUST_API_URL. Today's code silently warns and
+falls back to C++, so this test FAILS today by design — Tasks 3–5 will
+flip it green by removing the fallback wiring."
+```
+
+---
+
+## Task 3: Move the Rust availability check up + drop the fallback block
+
+**Goal:** Replace the `if (use_rust) { source rust ... } if (!use_rust) { source CPP ... }` block in `RCode/update_all_leagues_loop.R` (lines 26–45) with a single source-and-assert. Drop the `use_rust` parameter from the function signature. Re-run the regression test (positive case).
+
+**Files:**
+- Modify: `RCode/update_all_leagues_loop.R` (signature line 4–8; body lines 26–45)
+
+- [ ] **Step 1: Inspect the current state**
+
+```bash
+sed -n '4,8p;26,45p' RCode/update_all_leagues_loop.R
+```
+
+Expected output: the function signature with `use_rust = TRUE` as the last parameter, then the 20-line block containing the conditional source().
+
+- [ ] **Step 2: Edit the function signature (drop `use_rust` parameter)**
+
+Use the Edit tool. Find this exact text in `RCode/update_all_leagues_loop.R`:
+
+```r
+update_all_leagues_loop <- function(duration = 480, loops = 31, initial_wait = 0,
+                                         n = 10000, saison = "2023", 
+                                         TeamList_file = "RCode/TeamList_2023.csv",
+                                         shiny_directory = "/Users/christophschwerdtfeger/Library/CloudStorage/Dropbox-CSDataScience/Christoph Schwerdtfeger/Coding Projects/LeagueSimulator_Claude/League-Simulator-Update/ShinyApp",
+                                         use_rust = TRUE) {
+```
+
+Replace with:
+
+```r
+update_all_leagues_loop <- function(duration = 480, loops = 31, initial_wait = 0,
+                                    n = 10000, saison = "2023",
+                                    TeamList_file = "RCode/TeamList_2023.csv",
+                                    shiny_directory = "/Users/christophschwerdtfeger/Library/CloudStorage/Dropbox-CSDataScience/Christoph Schwerdtfeger/Coding Projects/LeagueSimulator_Claude/League-Simulator-Update/ShinyApp") {
+```
+
+(Drops `use_rust = TRUE` from the parameter list. Indentation on continuation lines normalized to 4 spaces — matches the surrounding pattern. The hardcoded Dropbox path stays untouched per the final code review of #78 which flagged it as out-of-scope.)
+
+- [ ] **Step 3: Replace the fallback block (lines 26–45 in the original) with a fail-fast source**
+
+Use the Edit tool. Find this exact text in `RCode/update_all_leagues_loop.R`:
+
+```r
+  # Source R Code
+  if (use_rust) {
+    message("=== Using high-performance Rust simulation engine ===")
+    source("RCode/rust_integration.R")
+    
+    # Check Rust connection
+    if (!connect_rust_simulator()) {
+      message("WARNING: Rust simulator not available, falling back to C++ implementation")
+      use_rust <- FALSE
+    }
+  }
+  
+  # Source traditional C++ implementation as fallback
+  if (!use_rust) {
+    message("=== Using traditional C++ simulation engine ===")
+    Rcpp::sourceCpp("RCode/SpielNichtSimulieren.cpp")
+    source("RCode/leagueSimulatorCPP.R")
+    source("RCode/SaisonSimulierenCPP.R")
+    source("RCode/simulationsCPP.R")
+    source("RCode/SpielCPP.R")
+  }
+```
+
+Replace with:
+
+```r
+  # Source the Rust REST client and assert the server is reachable before doing
+  # any work. Phase 1 of issue #77: the production loop now requires Rust;
+  # there is no in-process fallback to C++. A missing/broken Rust server fails
+  # the scheduler at startup so the operator sees the real problem instead of
+  # silent engine substitution.
+  source("RCode/rust_integration.R")
+  if (!connect_rust_simulator()) {
+    stop(sprintf(
+      "Rust simulator not available at %s. Check that the Rust server is running before starting the scheduler.",
+      Sys.getenv("RUST_API_URL", "http://localhost:8080")
+    ))
+  }
+```
+
+- [ ] **Step 4: Verify R can parse the modified file**
+
+```bash
+Rscript -e 'invisible(parse("RCode/update_all_leagues_loop.R")); cat("PARSE OK\n")'
+```
+
+Expected: `PARSE OK`. If R reports a parse error, the Edit corrupted something — inspect with `sed -n '20,40p' RCode/update_all_leagues_loop.R` and fix.
+
+- [ ] **Step 5: Re-run the regression test (positive case should still pass; negative still fails)**
+
+```bash
+Rscript -e 'testthat::test_file("tests/testthat/test-rust-required.R", reporter = "summary")'
+```
+
+Expected:
+- Positive: PASS or SKIP (depending on whether Rust binary is available locally).
+- Negative: STILL FAILS — because the `simulator_function` line at 104 and the `if (use_rust)` echoes at 109/117/125 still reference `use_rust`, which is now an undefined variable inside the function. The negative test will now fail with an `object 'use_rust' not found` error rather than the silent-fallback NULL it produced before. **This is intermediate breakage** — Tasks 4–5 finish the cleanup.
+
+This intermediate state is unavoidable in a TDD-style multi-step refactor. The next task (Task 4) inlines `simulator_function` and removes the `use_rust` references, which makes the negative test fail with a different error (still not yet the target `stop()` with `RUST_API_URL`). Task 5 then turns it green.
+
+If the Rust binary is unavailable and both tests skip, that's fine — Task 7's grep-based acceptance criteria are the final gate.
+
+- [ ] **Step 6: No commit yet**
+
+Task 4 finishes this group of changes and commits everything together (loop signature + body + simulator_function inlining + message updates) in one logically coherent commit. Hold off here.
+
+---
+
+## Task 4: Inline `simulator_function` and remove `use_rust` references in the loop body
+
+**Goal:** Remove the four references to `use_rust` and `simulator_function` in the loop body (lines 104, 108–109, 116–117, 124–125, 150–152). After this task, `RCode/update_all_leagues_loop.R` has zero references to `use_rust`, `simulator_function`, or `leagueSimulatorCPP`. Commit the loop changes (Tasks 3 + 4 together).
+
+**Files:**
+- Modify: `RCode/update_all_leagues_loop.R` (lines 104, 108–109, 116–117, 124–125, 150–152)
+
+- [ ] **Step 1: Inspect the current state of the loop body**
+
+```bash
+grep -n "use_rust\|simulator_function\|leagueSimulatorCPP" RCode/update_all_leagues_loop.R
+```
+
+After Task 3, expected matches (line numbers may have shifted slightly due to Task 3's edits — they shrunk the file by ~10 lines):
+
+- The `simulator_function` assignment (originally line 104)
+- Two `use_rust` references in `message()` calls per iteration (originally lines 109, 117, 125)
+- The closing summary message (originally line 150–152)
+
+- [ ] **Step 2: Remove the `simulator_function` assignment**
+
+Use the Edit tool. Find:
+
+```r
+    # Run the models using appropriate engine
+    simulator_function <- if (use_rust) leagueSimulatorRust else leagueSimulatorCPP
+```
+
+Replace with: empty (delete both lines, including the comment).
+
+- [ ] **Step 3: Replace the four `simulator_function(...)` call sites with `leagueSimulatorRust(...)`**
+
+Use the Edit tool with `replace_all = true` (the four call sites all look the same: `simulator_function(`).
+
+Find: `simulator_function(`
+Replace with: `leagueSimulatorRust(`
+
+Verify after: `grep -n "simulator_function" RCode/update_all_leagues_loop.R` → no output.
+
+- [ ] **Step 4: Simplify the three iteration messages (drop the `if (use_rust) "Rust" else "C++"` echo)**
+
+Use the Edit tool three times (one per league). Find this exact text:
+
+```r
+      message(sprintf("Loop %d: Simulating Bundesliga with %d simulations (%s engine)", 
+                      i, n, if (use_rust) "Rust" else "C++"))
+```
+
+Replace with:
+
+```r
+      message(sprintf("Loop %d: Simulating Bundesliga with %d simulations (Rust engine)",
+                      i, n))
+```
+
+Repeat for the 2. Bundesliga message:
+
+Find:
+```r
+      message(sprintf("Loop %d: Simulating 2. Bundesliga with %d simulations (%s engine)", 
+                      i, n, if (use_rust) "Rust" else "C++"))
+```
+
+Replace:
+```r
+      message(sprintf("Loop %d: Simulating 2. Bundesliga with %d simulations (Rust engine)",
+                      i, n))
+```
+
+Repeat for the 3. Liga message:
+
+Find:
+```r
+      message(sprintf("Loop %d: Simulating 3. Liga with %d simulations (%s engine)", 
+                      i, n, if (use_rust) "Rust" else "C++"))
+```
+
+Replace:
+```r
+      message(sprintf("Loop %d: Simulating 3. Liga with %d simulations (Rust engine)",
+                      i, n))
+```
+
+- [ ] **Step 5: Simplify the closing summary message**
+
+Use the Edit tool. Find:
+
+```r
+  message(sprintf("\n=== Completed all %d loops at %s ===", loops, format(Sys.time(), "%Y-%m-%d %H:%M:%S")))
+  if (use_rust) {
+    message("Performance boost achieved with Rust engine!")
+  }
+}
+```
+
+Replace with:
+
+```r
+  message(sprintf("\n=== Completed all %d loops at %s ===", loops, format(Sys.time(), "%Y-%m-%d %H:%M:%S")))
+}
+```
+
+(Drops the redundant "Performance boost" message; the loop is now unconditionally Rust so the message is noise.)
+
+- [ ] **Step 6: Verify zero `use_rust` references in the loop file**
+
+```bash
+grep -n "use_rust\|simulator_function" RCode/update_all_leagues_loop.R
+```
+
+Expected: no output. If anything shows, it's a missed reference — handle case-by-case.
+
+Also verify the file still parses:
+
+```bash
+Rscript -e 'invisible(parse("RCode/update_all_leagues_loop.R")); cat("PARSE OK\n")'
+```
+
+Expected: `PARSE OK`.
+
+- [ ] **Step 7: Update the file's header comment (optional but worth doing while we're here)**
+
+The file's header (line 1–2) reads:
+
+```r
+# Complete rerun of model using high-performance Rust engine
+# Provides 50-100x performance improvement over C++ implementation
+```
+
+Replace with:
+
+```r
+# Production simulation loop. Calls the Rust REST API exclusively
+# (issue #77 Phase 1: no in-process C++ fallback).
+```
+
+The "50-100x" comparison is now stale framing — there's no C++ to compare against in this file's call path.
+
+- [ ] **Step 8: Re-run the regression test**
+
+```bash
+Rscript -e 'testthat::test_file("tests/testthat/test-rust-required.R", reporter = "summary")'
+```
+
+Expected:
+- Positive: PASS or SKIP.
+- Negative: STILL FAILS, but with a different error than before — likely about the loop trying to call `retrieveResults` (which needs `httr` configured) before reaching the new `stop()` in Task 3's check. **This is still intermediate breakage.** Task 5 doesn't change the loop; it changes the scheduler. The negative test goes green only after Task 5 + the per-call fallback removal in Task 6 — but for this test, the green trigger is already in place (the `stop()` from Task 3). The remaining noise is the loop attempting to construct `season` data before erroring. We accept this and move on.
+
+If the negative test reaches `stop()` with `RUST_API_URL` in the message at this point, even better — the test goes green here.
+
+- [ ] **Step 9: Commit Tasks 3 + 4 together**
+
+```bash
+git add RCode/update_all_leagues_loop.R
+git commit -m "refactor: production loop calls leagueSimulatorRust unconditionally
+
+Issue #77 Phase 1. Removes the duplicated 'is Rust available?' check
+inside update_all_leagues_loop():
+
+- Drop the use_rust parameter from the signature.
+- Replace the if(use_rust)/if(!use_rust) source-on-demand block (~20
+  lines) with a single source(rust_integration.R) + connect_rust_simulator()
+  assertion. Failure now stop()s with the actual RUST_API_URL.
+- Inline the simulator_function dispatch — every call site now invokes
+  leagueSimulatorRust directly.
+- Drop 'Rust' vs 'C++' branching in iteration messages and the summary.
+- Update the file header to reflect the new contract.
+
+Per-call fallback in rust_integration.R is removed in the next commit;
+the scheduler-level warning becomes a stop() in the commit after that."
+```
+
+---
+
+## Task 5: Strip the per-call CPP fallback from `rust_integration.R`
+
+**Goal:** Remove the per-call `connect_rust_simulator()` check and `leagueSimulatorCPP` fallback inside `leagueSimulatorRust()` (lines 150–156 of `RCode/rust_integration.R`). Re-run the regression test.
+
+**Files:**
+- Modify: `RCode/rust_integration.R` (lines 150–156)
+
+- [ ] **Step 1: Inspect the current state**
+
+```bash
+sed -n '148,160p' RCode/rust_integration.R
+```
+
+Expected output (lines 148–158):
+
+```r
+                               adjGoalDiff = rep_len(0, numberTeams)) {
+
+  # Check Rust connection
+  if (!connect_rust_simulator()) {
+    message("Falling back to C++ implementation...")
+    return(leagueSimulatorCPP(season, n, modFactor, homeAdvantage,
+                              numberTeams, adjPoints, adjGoals,
+                              adjGoalsAgainst, adjGoalDiff))
+  }
+```
+
+- [ ] **Step 2: Remove the per-call check (Edit tool)**
+
+Find this exact text in `RCode/rust_integration.R`:
+
+```r
+  # Check Rust connection
+  if (!connect_rust_simulator()) {
+    message("Falling back to C++ implementation...")
+    return(leagueSimulatorCPP(season, n, modFactor, homeAdvantage,
+                              numberTeams, adjPoints, adjGoals,
+                              adjGoalsAgainst, adjGoalDiff))
+  }
+  
+```
+
+Replace with:
+
+```r
+  # Caller (update_all_leagues_loop) has already asserted Rust availability.
+  # Per-call connection checks were removed in issue #77 Phase 1; a Rust API
+  # call failure surfaces via stop() in simulate_league_rust() below.
+  
+```
+
+(Note the trailing blank line — preserve the spacing between this comment block and the next `# Convert tibble to data.frame if needed` block.)
+
+- [ ] **Step 3: Verify the per-call fallback is gone**
+
+```bash
+grep -n "leagueSimulatorCPP\|Falling back to C\+\+" RCode/rust_integration.R
+```
+
+Expected: no output. (`leagueSimulatorCPP` is no longer referenced anywhere in `rust_integration.R`.)
+
+- [ ] **Step 4: Verify R can parse the modified file**
+
+```bash
+Rscript -e 'invisible(parse("RCode/rust_integration.R")); cat("PARSE OK\n")'
+```
+
+Expected: `PARSE OK`.
+
+- [ ] **Step 5: Re-run the regression test**
+
+```bash
+Rscript -e 'testthat::test_file("tests/testthat/test-rust-required.R", reporter = "summary")'
+```
+
+Expected:
+- Positive: PASS or SKIP (unchanged from previous tasks).
+- Negative: now reaches the `stop()` from Task 3's check before doing anything else. The error message contains `RUST_API_URL` — the test passes.
+
+If the negative test still does not pass: inspect the actual error message with a manual run:
+
+```bash
+Rscript -e '
+Sys.setenv(RUST_API_URL = "http://127.0.0.1:1")
+source("RCode/update_all_leagues_loop.R")
+tryCatch(
+  update_all_leagues_loop(duration = 0, loops = 1, n = 10, saison = "2024",
+    TeamList_file = "tests/testthat/fixtures/rust-required/TeamList_minimal.csv",
+    shiny_directory = tempdir()),
+  error = function(e) cat("ERROR:", conditionMessage(e), "\n"))
+'
+```
+
+The error message must mention `RUST_API_URL`. If it doesn't, find out why — likely the test's working-directory assumption is wrong, or the loop is reaching some other code path before the assertion.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add RCode/rust_integration.R
+git commit -m "refactor: drop per-call CPP fallback in leagueSimulatorRust
+
+Issue #77 Phase 1. The per-call connect_rust_simulator() check inside
+leagueSimulatorRust() was a second-tier fallback that only worked under
+conditions the loop had to set up (sourcing the CPP files first). The
+loop now asserts Rust availability up front and stop()s on failure, so
+the per-call check is dead defensive code. Removing it makes the
+function single-purpose: call the Rust REST API; raise on failure.
+
+The negative regression test (test-rust-required.R) now passes — when
+Rust is unreachable, the loop stop()s with a message containing
+RUST_API_URL instead of silently substituting C++ results."
+```
+
+---
+
+## Task 6: Update the scheduler — warning becomes `stop()`, drop `use_rust` argument
+
+**Goal:** In `RCode/updateScheduler.R`, change the lines 155–158 warning to a `stop()`, and remove the now-invalid `use_rust = rust_available` argument from the `update_all_leagues_loop()` call at line 172. Run the season-transition smoke check (csv_generation.R is unchanged here, but season-transition's own `safe_source` may pick up some of the renamed files indirectly — the canary confirms no regression). Commit.
+
+**Files:**
+- Modify: `RCode/updateScheduler.R` (lines 151–172)
+
+- [ ] **Step 1: Inspect the current state**
+
+```bash
+sed -n '150,175p' RCode/updateScheduler.R
+```
+
+Expected output: `# Test Rust connection` comment, the `source()`+`connect_rust_simulator()` block, the warning, the `update_all_leagues_loop(...)` call with `use_rust = rust_available` as the last argument.
+
+- [ ] **Step 2: Replace the warning + `use_rust` plumbing in the scheduler's `main()`**
+
+Use the Edit tool. Find this exact text in `RCode/updateScheduler.R`:
+
+```r
+  # Test Rust connection
+  source("RCode/rust_integration.R")
+  rust_available <- connect_rust_simulator()
+  
+  if (!rust_available) {
+    message("WARNING: Rust engine not available, will use C++ fallback")
+    message("Performance will be significantly reduced")
+  }
+  
+  # Calculate optimal number of loops
+  loop_config <- calculate_loops()
+  
+  # Run the update loop with Rust engine
+  update_all_leagues_loop(
+    duration = loop_config$duration,  # Use actual time remaining, not DURATION
+    loops = loop_config$loops,
+    initial_wait = loop_config$initial_wait,
+    n = 10000,  # Can handle more iterations with Rust
+    saison = SEASON,
+    TeamList_file = team_list_file,
+    shiny_directory = "ShinyApp",
+    use_rust = rust_available
+  )
+```
+
+Replace with:
+
+```r
+  # Assert Rust availability at scheduler startup. Issue #77 Phase 1: there is
+  # no in-process fallback to C++. A missing Rust server fails the scheduler
+  # here so the operator sees the real cause; the loop's own assertion is the
+  # second-tier guard against the server dying mid-run.
+  source("RCode/rust_integration.R")
+  if (!connect_rust_simulator()) {
+    stop(sprintf(
+      "Rust simulator not available at %s. Start the Rust server before invoking this scheduler.",
+      RUST_API_URL
+    ))
+  }
+  
+  # Calculate optimal number of loops
+  loop_config <- calculate_loops()
+  
+  # Run the update loop. Rust availability has already been asserted above.
+  update_all_leagues_loop(
+    duration = loop_config$duration,  # Use actual time remaining, not DURATION
+    loops = loop_config$loops,
+    initial_wait = loop_config$initial_wait,
+    n = 10000,
+    saison = SEASON,
+    TeamList_file = team_list_file,
+    shiny_directory = "ShinyApp"
+  )
+```
+
+(The argument list to `update_all_leagues_loop()` no longer includes `use_rust = rust_available` because Task 3 removed that parameter from the function signature. Comment "Can handle more iterations with Rust" simplified to nothing — the comment was a comparison to the deleted alternative.)
+
+- [ ] **Step 3: Verify zero `rust_available` and zero `use_rust` references in the scheduler**
+
+```bash
+grep -n "rust_available\|use_rust" RCode/updateScheduler.R
+```
+
+Expected: no output.
+
+- [ ] **Step 4: Verify R can parse the file**
+
+```bash
+Rscript -e 'invisible(parse("RCode/updateScheduler.R")); cat("PARSE OK\n")'
+```
+
+Expected: `PARSE OK`.
+
+- [ ] **Step 5: Run the season-transition smoke check (canary)**
+
+```bash
+Rscript -e 'tryCatch(source("scripts/season_transition.R"), error = function(e) cat("ERROR:", e$message, "\n"))' 2>&1 | tee /tmp/season-transition-after-task6.txt
+diff /tmp/season-transition-baseline-phase1.txt /tmp/season-transition-after-task6.txt
+echo "diff_exit=$?"
+```
+
+Expected: `diff_exit=0` — byte-identical to the baseline captured in Task 1 Step 8. Phase 1 deliberately does not touch any season-transition file, so the baseline must hold.
+
+If the diff is non-zero: STOP and report BLOCKED. Something in Tasks 3–5 affected season-transition through a transitive dependency we missed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add RCode/updateScheduler.R
+git commit -m "refactor: scheduler stop()s on Rust unavailability instead of warning
+
+Issue #77 Phase 1. The scheduler used to log 'WARNING: Rust engine not
+available, will use C++ fallback' and proceed; it now stop()s with a
+message naming RUST_API_URL. Drops the use_rust = rust_available
+argument from the update_all_leagues_loop() call (the parameter was
+removed from the loop's signature in the prior commit).
+
+Season-transition smoke check passes byte-identical to baseline."
+```
+
+---
+
+## Task 7: Update the Dockerfile — remove the runtime `Rcpp::sourceCpp` build step
+
+**Goal:** Delete `Dockerfile` lines 101–104 (the `# Compile C++ code (fallback when Rust unavailable)` block). Rebuild the production image. Confirm parity with the Task-1 baseline.
+
+**Files:**
+- Modify: `Dockerfile` (lines 101–104)
+
+- [ ] **Step 1: Inspect the current state**
+
+```bash
+sed -n '99,106p' Dockerfile
+```
+
+Expected output:
+
+```
+COPY ShinyApp/ ./ShinyApp/
+
+# Compile C++ code (fallback when Rust unavailable)
+RUN cd /app/RCode && \
+    R -e "Rcpp::sourceCpp('SpielNichtSimulieren.cpp')" || \
+    echo "Warning: C++ compilation failed, will rely on Rust engine"
+
+# Copy robust startup script
+```
+
+- [ ] **Step 2: Remove the block**
+
+Use the Edit tool. Find this exact text in `Dockerfile`:
+
+```
+# Compile C++ code (fallback when Rust unavailable)
+RUN cd /app/RCode && \
+    R -e "Rcpp::sourceCpp('SpielNichtSimulieren.cpp')" || \
+    echo "Warning: C++ compilation failed, will rely on Rust engine"
+
+```
+
+Replace with: empty (delete the whole block including the trailing blank line).
+
+- [ ] **Step 3: Verify the block is gone**
+
+```bash
+grep -n "Rcpp::sourceCpp\|Compile C++ code\|fallback when Rust" Dockerfile
+```
+
+Expected: no output.
+
+- [ ] **Step 4: Verify the Dockerfile structure is still coherent**
+
+```bash
+sed -n '99,103p' Dockerfile
+```
+
+Expected output: `COPY ShinyApp/ ./ShinyApp/` immediately followed (with one blank line) by `# Copy robust startup script` and `COPY docker-start.sh /app/start.sh`. No orphaned `RUN` or comment fragments.
+
+- [ ] **Step 5: Build the post-refactor image**
+
+Use the nohup pattern:
+
+```bash
+cd <worktree-absolute-path>
+nohup docker build -f Dockerfile -t league-simulator:phase1-post . > /tmp/docker-build-phase1-post.log 2>&1 & disown
+echo "PID: $!"
+```
+
+Poll `tail /tmp/docker-build-phase1-post.log` until `Successfully tagged league-simulator:phase1-post` or an error.
+
+Expected: build succeeds. Cache hit on most layers; only `COPY RCode/` and everything after may re-run because RCode/ contents changed in Tasks 3–5. The C++ compile step is gone, so total layer count drops by 1.
+
+If the build fails: STOP and report BLOCKED with the build log tail.
+
+- [ ] **Step 6: Compare layer counts**
+
+```bash
+PRE=$(docker history --no-trunc --format '{{.ID}}' league-simulator:phase1-pre | wc -l)
+POST=$(docker history --no-trunc --format '{{.ID}}' league-simulator:phase1-post | wc -l)
+echo "Pre-Phase-1 layers: $PRE"
+echo "Post-Phase-1 layers: $POST"
+```
+
+Expected: post-cleanup count is `pre - 1` (one fewer layer because the `Rcpp::sourceCpp` RUN step is gone). Could also be equal if Docker's cache squashed in some surprising way; off by ≤1 is acceptable.
+
+- [ ] **Step 7: Smoke test the container — Rust server starts and the scheduler boots**
+
+```bash
+docker run --rm -d --name phase1-smoke \
+  -e RAPIDAPI_KEY=dummy_for_smoke \
+  -e SHINYAPPS_IO_SECRET=dummy_for_smoke \
+  league-simulator:phase1-post
+
+sleep 8
+docker logs phase1-smoke 2>&1 | grep -E "Rust server ready|RUST_API_URL|ERROR" | head -10
+docker stop phase1-smoke
+```
+
+Expected behavior in the logs:
+- `✅ Rust server ready on port 8080` — confirms the Rust binary started cleanly.
+- The scheduler will then likely fail because `RAPIDAPI_KEY=dummy_for_smoke` won't validate; that's OK — what we're proving is that the Rust startup contract still works.
+
+If you see `Rcpp::sourceCpp` errors in the logs or "C++ compilation failed" warnings: STOP and report — the build step removal somehow regressed something.
+
+- [ ] **Step 8: Final source-code grep — zero stale `use_rust` / `simulator_function` / per-call fallback references**
+
+```bash
+grep -rEn "use_rust|simulator_function|leagueSimulatorCPP" RCode/update_all_leagues_loop.R RCode/rust_integration.R RCode/updateScheduler.R Dockerfile
+```
+
+Expected: no output. (The `leagueSimulatorCPP` survivor file at `RCode/leagueSimulatorCPP.R` will, of course, contain the function — but the *production seam files* must not reference it.)
+
+If any match appears, fix the file before committing.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add Dockerfile
+git commit -m "build: remove unused Rcpp::sourceCpp step from Dockerfile
+
+Issue #77 Phase 1. The runtime 'R -e Rcpp::sourceCpp(SpielNichtSimulieren.cpp)'
+step was the only consumer of the C++ build artifact inside the
+container — and the only consumer of that artifact was the
+update_all_leagues_loop fallback path, which was removed in the prior
+commits. The C++ source files still come along via COPY RCode/ but are
+inert in the container; the host-side season-transition workflow that
+sources SpielCPP.R runs outside the container.
+
+The line that documented its own failure mode ('Warning: C++ compilation
+failed, will rely on Rust engine') is gone — failures now surface as
+the actual root cause."
+```
+
+---
+
+## Task 8: Final acceptance grep + season-transition smoke + commit summary
+
+**Goal:** Verify the PRD's Phase 1 acceptance criteria pass against the cleaned-up tree. No commits.
+
+**Files:** None modified.
+
+- [ ] **Step 1: Run the source-code-scoped legacy-fallback grep**
+
+```bash
+grep -rEn "use_rust|simulator_function|leagueSimulatorCPP|Rcpp::sourceCpp|C\+\+ fallback|Falling back to C\+\+" \
+  RCode/update_all_leagues_loop.R \
+  RCode/rust_integration.R \
+  RCode/updateScheduler.R \
+  Dockerfile 2>/dev/null
+```
+
+Expected: no output. (Other files in `RCode/` may legitimately mention `leagueSimulatorCPP` — those are the survivors. The four production seam files are the ones that must be clean.)
+
+- [ ] **Step 2: Confirm the C++ engine survivors are still present**
+
+```bash
+ls RCode/leagueSimulatorCPP.R RCode/simulationsCPP.R RCode/SaisonSimulierenCPP.R RCode/SpielCPP.R RCode/SpielNichtSimulieren.cpp RCode/cpp_wrappers.R RCode/RcppExports.R
+```
+
+Expected: all 7 files listed cleanly. Phase 1 keeps them.
+
+- [ ] **Step 3: Run the regression test one final time**
+
+```bash
+Rscript -e 'testthat::test_file("tests/testthat/test-rust-required.R", reporter = "summary")'
+```
+
+Expected:
+- Positive test: PASS (with Rust binary built per Task 1) or SKIP.
+- Negative test: PASS — the `stop()` with `RUST_API_URL` happens.
+
+If both PASS or both SKIP, that's the green state. If the positive PASSes and the negative FAILs, that's a defect — stop and investigate.
+
+- [ ] **Step 4: Final season-transition canary**
+
+```bash
+Rscript -e 'tryCatch(source("scripts/season_transition.R"), error = function(e) cat("ERROR:", e$message, "\n"))' 2>&1 | tee /tmp/season-transition-final.txt
+diff /tmp/season-transition-baseline-phase1.txt /tmp/season-transition-final.txt
+echo "diff_exit=$?"
+```
+
+Expected: `diff_exit=0` — byte-identical to Task 1's baseline.
+
+- [ ] **Step 5: `docker compose config` final check**
+
+```bash
+docker compose config > /dev/null && echo "compose OK"
+```
+
+Expected: `compose OK` (env-var warnings on stderr are fine).
+
+- [ ] **Step 6: Show the cumulative diff summary**
+
+```bash
+git log --oneline main..HEAD
+echo '---'
+git diff --shortstat main..HEAD
+```
+
+Expected: 4 commits (Tasks 2, 3+4, 5, 6, 7 = 5 commits if Tasks 3+4 land separately, but the plan combined them). The diff-stat should be approximately:
+
+- ~50 line deletions (loop fallback block + per-call fallback + warning + Dockerfile step + `use_rust` references + Performance message + dispatch line)
+- ~30 line insertions (the new fail-fast `stop()` calls + the new test file + the comment updates)
+- ~3–4 files modified (`update_all_leagues_loop.R`, `rust_integration.R`, `updateScheduler.R`, `Dockerfile`) plus the test fixture and the test file (created)
+
+- [ ] **Step 7: No commit**
+
+Verification-only.
+
+---
+
+## Acceptance Criteria Mapping (PRD ↔ Plan)
+
+| PRD Acceptance Criterion (Phase 1) | Implementing Task(s) |
+|---|---|
+| `RCode/rust_integration.R` no longer calls `leagueSimulatorCPP` | Task 5 |
+| `RCode/update_all_leagues_loop.R` does not contain `use_rust`, `leagueSimulatorCPP`, `SaisonSimulierenCPP`, `simulationsCPP`, `Rcpp::sourceCpp` | Tasks 3 + 4 |
+| `RCode/update_all_leagues_loop.R` calls `leagueSimulatorRust` directly (no `simulator_function`) | Task 4 |
+| Scheduler exits non-zero with `RUST_API_URL` in message when Rust unreachable | Task 6 |
+| `Dockerfile` no longer contains the `Rcpp::sourceCpp` build step | Task 7 |
+| CPP source files **remain** in `RCode/` | Task 8 Step 2 (verification) |
+| `tests/testthat/test-*CPP*.R` files: status verified, not deleted | Task 8 implicit (no deletion happens) |
+| `compare_rust_cpp.R`, etc., not deleted | Task 8 implicit |
+| End-to-end test exists for `update_all_leagues_loop()` | Task 2 (created) |
+| Docker image still builds + healthy Rust server + first iteration | Task 7 Steps 5–7 |
+| Season-transition smoke test still passes | Tasks 6 + 8 (canary) |
+
+## Self-Review Notes
+
+Performed before publishing:
+
+1. **Spec coverage:** All 11 PRD Phase-1 acceptance criteria map to a task. The "What to do with existing CPP testthat files" decision is explicitly deferred to issue #76 (CI rebuild) per the PRD.
+
+2. **Placeholder scan:** Every task step has either a concrete shell command, a code block to write/edit, or an explicit verification command. The `with_repo_root` helper in the test is concrete (sets cwd to repo root). No "TBD", no "fill in", no "similar to Task N".
+
+3. **Type / name consistency:** The function signature changes consistently (`update_all_leagues_loop` keeps name; loses `use_rust` parameter in Task 3; the call in Task 6 also drops `use_rust = rust_available`). `leagueSimulatorRust` keeps its name throughout. `RUST_API_URL` is referenced via `Sys.getenv("RUST_API_URL", ...)` in Task 3 (loop) and as a top-level variable in Task 6 (scheduler, since it's set at line 9) — both correct in their respective contexts.
+
+4. **Test fixture realism:** The `TeamList_minimal.csv` fixture has 4 columns (`TeamID;ShortName;Promotion;InitialELO`) and 4 teams. The real `TeamList_2025.csv` may have more columns; if the loop errors on missing columns during the positive test, the fix is to widen the fixture, not narrow the loop. The plan's Task 2 Step 2 explicitly anticipates this.

--- a/docs/superpowers/plans/2026-05-03-season-transition-test-coverage.md
+++ b/docs/superpowers/plans/2026-05-03-season-transition-test-coverage.md
@@ -1,0 +1,837 @@
+# Season-Transition Test-Coverage Gap Fill — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a regression net (engine-selection unit test, api-football cassette fixtures, end-to-end CSV snapshot test, plus a one-line env-var-gated probe) that pins current behavior of the season-transition workflow before the Phase-2 refactor at `docs/prds/2026-05-03-simulation-engine-seam-phase-2.md` runs.
+
+**Architecture:** Three new test artifacts in `tests/testthat/`, one new test dependency (`httptest2`), and one minimal-blast-radius env-var-gated probe in `RCode/elo_aggregation.R`. The snapshot test runs `scripts/season_transition.R` in a real `Rscript` subprocess inside `withr::with_dir(temp_dir)` with `httptest2::with_mock_dir` cassette playback. Tests are non-destructive and ship before the Phase-2 plan executes.
+
+**Tech Stack:** R 4.3.1, testthat 3.x, httptest2 (new), Rcpp (already a dep), withr (already a dep), base R `system2` for subprocess invocation.
+
+**Spec:** `docs/superpowers/specs/2026-05-03-season-transition-test-coverage-design.md`
+
+---
+
+## File Structure
+
+| Path | Action | Purpose |
+|---|---|---|
+| `test_packagelist.txt` | Modify | Add `httptest2` and `withr` (latter may already be transitive — verify and only add if missing) |
+| `RCode/elo_aggregation.R` | Modify (one block) | Env-var-gated probe immediately above existing line 225 guard |
+| `tests/testthat/test-elo-aggregation-engine-selection.R` | Create | Gap #1: pin C++-path output, R-fallback output, and whether they agree |
+| `tests/testthat/fixtures/season-transition-2024-to-2025/` | Create | Cassette directory + expected CSV snapshot + re-record README |
+| `tests/testthat/fixtures/season-transition-2024-to-2025/README.md` | Create | Re-record procedure doc |
+| `tests/testthat/fixtures/season-transition-2024-to-2025/TeamList_2025.csv.snapshot` | Create | Captured expected output |
+| `tests/testthat/test-season-transition-csv-snapshot.R` | Create | Gap #2 + gap #3: end-to-end snapshot + probe assertion |
+
+---
+
+## Pre-flight: install httptest2 locally
+
+This plan assumes `httptest2` is installed in your local R environment before running any tests. Once Task 1 lands, CI under #76 will install it from `test_packagelist.txt`. For local dev:
+
+```r
+install.packages("httptest2")
+```
+
+If that fails (uncommon), see https://enpiar.com/httptest2/ for installation troubleshooting.
+
+---
+
+## Task 1: Add httptest2 to test dependencies
+
+**Files:**
+- Modify: `test_packagelist.txt`
+
+- [ ] **Step 1: Read the current file**
+
+```bash
+cat test_packagelist.txt
+```
+
+Expected output: 12 lines, last one is `lubridate`. No `httptest2`. Verify `withr` is also absent (it is — we'll add it too if it isn't already a transitive dep covered elsewhere).
+
+- [ ] **Step 2: Append httptest2 (and withr only if not already in packagelist.txt)**
+
+Check `packagelist.txt` (production) for `withr`:
+
+```bash
+grep -i "^withr$" packagelist.txt
+```
+
+If empty, withr is not a runtime dep — add it to the test list. Edit `test_packagelist.txt`, appending exactly:
+
+```
+httptest2
+```
+
+If `grep` returned nothing, also append on a new line:
+
+```
+withr
+```
+
+- [ ] **Step 3: Verify install locally**
+
+```r
+install.packages(c("httptest2", "withr"))
+library(httptest2)
+library(withr)
+```
+
+Expected: both packages load without error.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test_packagelist.txt
+git commit -m "$(cat <<'EOF'
+test(#77): add httptest2 + withr to test dependencies
+
+Required by upcoming season-transition CSV snapshot test
+(docs/superpowers/specs/2026-05-03-season-transition-test-coverage-design.md).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Engine-selection unit test (C++ path)
+
+**Files:**
+- Create: `tests/testthat/test-elo-aggregation-engine-selection.R`
+
+The hand-derived expected ELO for the C++ path is computed from `RCode/SpielNichtSimulieren.cpp:18-32`:
+
+```
+ELODeltaInv = 1500 - 1500 - 100 = -100  (clamped to [-400, 400] → -100)
+ELOProb     = 1 / (1 + 10^(-100/400)) = 1 / (1 + 10^(-0.25))
+            = 1 / (1 + 0.5623413...) = 1 / 1.5623413... = 0.6400649...
+goalDiff    = 2 - 0 = 2
+result      = ((0 < 2) - (2 < 0) + 1) / 2 = (1 - 0 + 1) / 2 = 1.0
+goalMod     = sqrt(max(2, 1)) = sqrt(2) = 1.41421356...
+ELOMod      = (1.0 - 0.6400649) * 1.41421356 * 20 = 0.3599351 * 28.2842712
+            = 10.18028...
+
+Expected:
+  home_new_elo = 1500 + 10.18028 = 1510.18028  (C++ home gets POSITIVE delta — but note
+                                                   SpielNichtSimulieren computes ELODeltaInv
+                                                   = away - home - homeAdv, so the
+                                                   modificator is added to home and
+                                                   subtracted from away)
+  away_new_elo = 1500 - 10.18028 = 1489.81972
+```
+
+We use `expect_equal(..., tolerance = 1e-4)` to accommodate `qpois`/floating-point differences.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/testthat/test-elo-aggregation-engine-selection.R`:
+
+```r
+# Engine-selection regression net for update_elos_for_match.
+#
+# RCode/elo_aggregation.R:225 uses `if (exists("SpielNichtSimulieren"))` and
+# falls back to a pure-R calculate_elo_update if the C++ primitive isn't loaded.
+# This file pins:
+#   1) The C++-path output (with SpielNichtSimulieren defined).
+#   2) The R-fallback output (with SpielNichtSimulieren NOT defined).
+#   3) Whether the two paths agree.
+#
+# The agreement test's verdict is the load-bearing input to the Phase-2 PRD's
+# Option A vs Option B branch (docs/prds/2026-05-03-simulation-engine-seam-phase-2.md).
+#
+# helper-test-setup.R sources SpielNichtSimulieren.cpp at suite startup, so the
+# C++ primitive is available globally. The R-fallback test must hide it locally.
+
+library(testthat)
+
+# Build a fixed match record and elo table for all three tests.
+fixture_match <- function() {
+  data.frame(
+    teams_home_id = 1L,
+    teams_away_id = 2L,
+    goals_home = 2,
+    goals_away = 0,
+    stringsAsFactors = FALSE
+  )
+}
+
+fixture_elos <- function() {
+  data.frame(
+    TeamID = c(1L, 2L),
+    CurrentELO = c(1500, 1500),
+    stringsAsFactors = FALSE
+  )
+}
+
+test_that("update_elos_for_match returns C++-path ELOs when SpielNichtSimulieren is defined", {
+  # Precondition: helper-test-setup.R has sourced SpielNichtSimulieren.cpp
+  skip_if_not(exists("SpielNichtSimulieren"),
+              "SpielNichtSimulieren must be available; check helper-test-setup.R")
+
+  result <- update_elos_for_match(fixture_elos(), fixture_match())
+
+  # Hand-computed from SpielNichtSimulieren.cpp:18-32 with mod_factor=20,
+  # home_advantage=100, ELOs (1500, 1500), goals (2, 0):
+  #   ELODeltaInv = -100, ELOProb = 1/(1+10^-0.25) = 0.6400649
+  #   goalMod    = sqrt(2) = 1.41421356
+  #   ELOMod     = (1.0 - 0.6400649) * 1.41421356 * 20 = 10.18028
+  expected_home <- 1500 + 10.18028
+  expected_away <- 1500 - 10.18028
+
+  expect_equal(result$CurrentELO[result$TeamID == 1L], expected_home, tolerance = 1e-4)
+  expect_equal(result$CurrentELO[result$TeamID == 2L], expected_away, tolerance = 1e-4)
+})
+
+test_that("update_elos_for_match falls back to calculate_elo_update when SpielNichtSimulieren is hidden", {
+  # We can't unload the cpp from the test session, so override `exists()` in a
+  # local scope to lie about SpielNichtSimulieren's availability. update_elos_for_match
+  # uses base::exists(), which R's lexical lookup will resolve to our shadow when
+  # the call is evaluated inside `with(list(exists = ...))`.
+  shadow_exists <- function(x, ...) {
+    if (identical(x, "SpielNichtSimulieren")) return(FALSE)
+    base::exists(x, ...)
+  }
+
+  result <- with(list(exists = shadow_exists),
+                 update_elos_for_match(fixture_elos(), fixture_match()))
+
+  # Hand-computed from calculate_elo_update at elo_aggregation.R:252 with same inputs:
+  #   elo_diff       = (1500 - 1500 - 100) = -100, clamped to -100
+  #   expected_prob  = 1 / (1 + 10^(-0.25)) = 0.6400649
+  #   actual_result  = (sign(2) + 1) / 2 = 1.0
+  #   goal_modifier  = sqrt(max(2, 1)) = 1.41421356
+  #   elo_change     = (1.0 - 0.6400649) * 1.41421356 * 20 = 10.18028
+  # Same formula as C++. So we expect equality.
+  expected_home <- 1500 + 10.18028
+  expected_away <- 1500 - 10.18028
+
+  expect_equal(result$CurrentELO[result$TeamID == 1L], expected_home, tolerance = 1e-4)
+  expect_equal(result$CurrentELO[result$TeamID == 2L], expected_away, tolerance = 1e-4)
+})
+
+test_that("C++ and R fallback engines produce equivalent ELO updates across a parameter sweep", {
+  skip_if_not(exists("SpielNichtSimulieren"),
+              "SpielNichtSimulieren must be available")
+
+  scenarios <- list(
+    list(home = 1500, away = 1500, gh = 2, ga = 0, label = "home_win_equal"),
+    list(home = 1700, away = 1300, gh = 1, ga = 1, label = "draw_asymmetric"),
+    list(home = 1300, away = 1700, gh = 0, ga = 3, label = "away_blowout"),
+    list(home = 1500, away = 1500, gh = 1, ga = 1, label = "draw_equal"),
+    list(home = 1600, away = 1400, gh = 3, ga = 2, label = "home_close_win")
+  )
+
+  shadow_exists <- function(x, ...) {
+    if (identical(x, "SpielNichtSimulieren")) return(FALSE)
+    base::exists(x, ...)
+  }
+
+  for (s in scenarios) {
+    elos <- data.frame(TeamID = c(1L, 2L), CurrentELO = c(s$home, s$away))
+    match <- data.frame(teams_home_id = 1L, teams_away_id = 2L,
+                        goals_home = s$gh, goals_away = s$ga)
+
+    cpp_result <- update_elos_for_match(elos, match)
+
+    r_result <- with(list(exists = shadow_exists),
+                     update_elos_for_match(elos, match))
+
+    expect_equal(cpp_result$CurrentELO[1], r_result$CurrentELO[1],
+                 tolerance = 1e-4,
+                 info = sprintf("scenario %s: home ELO C++ vs R", s$label))
+    expect_equal(cpp_result$CurrentELO[2], r_result$CurrentELO[2],
+                 tolerance = 1e-4,
+                 info = sprintf("scenario %s: away ELO C++ vs R", s$label))
+  }
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails initially OR passes**
+
+```bash
+cd "/Users/christophschwerdtfeger/Library/CloudStorage/Dropbox/Coding Projects/LeagueSimulator_Claude/League-Simulator-Update"
+Rscript -e 'testthat::test_file("tests/testthat/test-elo-aggregation-engine-selection.R")'
+```
+
+Expected: All three `test_that` blocks PASS. (This is a regression net pinning current behavior — if the test fails on first run, the hand-computed expected values need correction. See Step 3.)
+
+- [ ] **Step 3: If test 1 or test 2 fails, recompute expected values**
+
+If `expect_equal(result$CurrentELO[result$TeamID == 1L], 1510.18028, tolerance = 1e-4)` fails with an actual value that's still close to 1510 but off in the 4th decimal, replace the expected value with the actual (the formula is the truth; the hand-calc may have rounded).
+
+If test 3 (agreement) fails, that is a *real signal* — the C++ and R formulas diverge. Update the test 3 assertion to reflect the divergence:
+
+```r
+# Replace the agreement assertions with:
+expect_false(isTRUE(all.equal(cpp_result$CurrentELO[1], r_result$CurrentELO[1],
+                              tolerance = 1e-6)),
+             info = sprintf("scenario %s: C++ and R diverge — Phase-2 must use Option A", s$label))
+```
+
+Document the divergence in a comment at the top of the file. The Phase-2 PRD's Option A vs Option B branch hinges on this answer; recording divergence here is the test's job, not a bug.
+
+- [ ] **Step 4: Re-run after any expected-value corrections**
+
+```bash
+Rscript -e 'testthat::test_file("tests/testthat/test-elo-aggregation-engine-selection.R")'
+```
+
+Expected: 3 passing tests (or 3 passing tests with the divergence-asserting variant of test 3).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/testthat/test-elo-aggregation-engine-selection.R
+git commit -m "$(cat <<'EOF'
+test(#77): pin elo-aggregation engine selection (C++ vs R fallback)
+
+Three tests in tests/testthat/test-elo-aggregation-engine-selection.R:
+  1. C++-path ELO output with SpielNichtSimulieren defined
+  2. R-fallback ELO output via shadow exists() override
+  3. Cross-engine agreement check across 5 scenarios
+
+The agreement test pins whether C++ and R formulas produce equivalent
+results — the load-bearing question for Phase-2 PRD Option A vs Option B
+(docs/prds/2026-05-03-simulation-engine-seam-phase-2.md).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Add the env-var-gated probe to elo_aggregation.R
+
+**Files:**
+- Modify: `RCode/elo_aggregation.R:206-225` (insert one block immediately above the existing `if (exists(...))` guard)
+
+- [ ] **Step 1: Write the failing test**
+
+Add a test that the probe writes the right value when the env var is set. Append to `tests/testthat/test-elo-aggregation-engine-selection.R`:
+
+```r
+test_that("probe writes engine availability when SEASON_TRANSITION_ENGINE_PROBE is set", {
+  skip_if_not(exists("SpielNichtSimulieren"),
+              "SpielNichtSimulieren must be available")
+
+  probe_path <- tempfile(fileext = ".txt")
+  on.exit(unlink(probe_path), add = TRUE)
+
+  withr::with_envvar(
+    list(SEASON_TRANSITION_ENGINE_PROBE = probe_path),
+    {
+      update_elos_for_match(fixture_elos(), fixture_match())
+    }
+  )
+
+  expect_true(file.exists(probe_path))
+  expect_equal(readLines(probe_path)[1], "TRUE")
+})
+
+test_that("probe is silent when SEASON_TRANSITION_ENGINE_PROBE is unset", {
+  skip_if_not(exists("SpielNichtSimulieren"),
+              "SpielNichtSimulieren must be available")
+
+  # Confirm env var is not set in the test runner.
+  withr::with_envvar(
+    list(SEASON_TRANSITION_ENGINE_PROBE = NA),
+    {
+      # Should not raise, should not write any file.
+      result <- update_elos_for_match(fixture_elos(), fixture_match())
+      expect_s3_class(result, "data.frame")
+    }
+  )
+})
+```
+
+- [ ] **Step 2: Run the new tests to verify failure**
+
+```bash
+Rscript -e 'testthat::test_file("tests/testthat/test-elo-aggregation-engine-selection.R")'
+```
+
+Expected: 3 PASS (existing) + 1 FAIL ("probe writes engine availability ...": file does not exist) + 1 PASS (silent when unset, since no probe code yet).
+
+- [ ] **Step 3: Add the probe to elo_aggregation.R**
+
+Open `RCode/elo_aggregation.R`. Find line 224 (just above `if (exists("SpielNichtSimulieren"))`). Insert this block immediately above line 225:
+
+```r
+  # Test probe: when SEASON_TRANSITION_ENGINE_PROBE is set, write whether the C++
+  # primitive is available to that file path. Off by default; production unaffected.
+  # Removed during Phase-2 refactor along with the exists() guard below
+  # (see docs/prds/2026-05-03-simulation-engine-seam-phase-2.md and
+  # docs/superpowers/specs/2026-05-03-season-transition-test-coverage-design.md).
+  if (Sys.getenv("SEASON_TRANSITION_ENGINE_PROBE") != "") {
+    writeLines(as.character(exists("SpielNichtSimulieren")),
+               Sys.getenv("SEASON_TRANSITION_ENGINE_PROBE"))
+  }
+
+  # Use existing ELO calculation if available
+  if (exists("SpielNichtSimulieren")) {
+```
+
+So the resulting block runs from line 222 onward and looks like:
+
+```r
+  if (length(home_elo) == 0 || length(away_elo) == 0) {
+    warning(paste("Team not found in ELO data for match:", home_team_id, "vs", away_team_id))
+    return(current_elos)
+  }
+
+  # Test probe: when SEASON_TRANSITION_ENGINE_PROBE is set, write whether the C++
+  # primitive is available to that file path. Off by default; production unaffected.
+  # Removed during Phase-2 refactor along with the exists() guard below
+  # (see docs/prds/2026-05-03-simulation-engine-seam-phase-2.md and
+  # docs/superpowers/specs/2026-05-03-season-transition-test-coverage-design.md).
+  if (Sys.getenv("SEASON_TRANSITION_ENGINE_PROBE") != "") {
+    writeLines(as.character(exists("SpielNichtSimulieren")),
+               Sys.getenv("SEASON_TRANSITION_ENGINE_PROBE"))
+  }
+
+  # Use existing ELO calculation if available
+  if (exists("SpielNichtSimulieren")) {
+    # Use standard parameters
+    mod_factor <- 20  # Standard K-factor
+    ...
+```
+
+- [ ] **Step 4: Re-run all engine-selection tests**
+
+```bash
+Rscript -e 'testthat::test_file("tests/testthat/test-elo-aggregation-engine-selection.R")'
+```
+
+Expected: 5 PASS (3 original + 2 probe tests).
+
+- [ ] **Step 5: Verify production code still parses cleanly**
+
+```bash
+Rscript -e 'invisible(parse("RCode/elo_aggregation.R")); cat("OK\n")'
+```
+
+Expected: `OK`.
+
+- [ ] **Step 6: Verify the full test suite still passes (regression check)**
+
+```bash
+Rscript -e 'testthat::test_dir("tests/testthat")' 2>&1 | tail -30
+```
+
+Expected: No new failures attributable to the probe addition. Pre-existing failures (if any) unchanged.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add RCode/elo_aggregation.R tests/testthat/test-elo-aggregation-engine-selection.R
+git commit -m "$(cat <<'EOF'
+test(#77): add env-var-gated probe to elo_aggregation for snapshot test
+
+Adds a one-line probe immediately above the existing exists() guard at
+RCode/elo_aggregation.R:225. When SEASON_TRANSITION_ENGINE_PROBE is set,
+writes the C++ primitive's availability to that file. Off by default;
+production unaffected. Removed during Phase-2 refactor.
+
+Tests cover both probe-active and probe-silent paths.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Capture the api-football cassettes
+
+**Files:**
+- Create: `tests/testthat/fixtures/season-transition-2024-to-2025/` (directory)
+- Create: `tests/testthat/fixtures/season-transition-2024-to-2025/README.md`
+- Create: `tests/testthat/fixtures/season-transition-2024-to-2025/<httptest2-cassette-files>` (~10-15 JSON files)
+- Create: `tests/testthat/fixtures/season-transition-2024-to-2025/TeamList_2025.csv.snapshot`
+
+**Prerequisite:** A valid `RAPIDAPI_KEY` in your environment with quota remaining. If you don't have one, **stop this task and surface the blocker to the user** — cassette capture requires real API access.
+
+- [ ] **Step 1: Create the fixture directory**
+
+```bash
+mkdir -p "tests/testthat/fixtures/season-transition-2024-to-2025"
+```
+
+- [ ] **Step 2: Write the recording script**
+
+Create `tests/testthat/fixtures/season-transition-2024-to-2025/_record.R` (the leading underscore keeps it out of testthat discovery):
+
+```r
+# One-time cassette recording for the season-transition snapshot test.
+# Run manually with: Rscript tests/testthat/fixtures/season-transition-2024-to-2025/_record.R
+# Requires RAPIDAPI_KEY in the environment.
+#
+# After running, inspect the captured JSON files for any sensitive content,
+# then commit. Re-run only when the api-football response shape changes.
+
+stopifnot(Sys.getenv("RAPIDAPI_KEY") != "")
+
+library(httptest2)
+library(withr)
+
+fixture_dir <- "tests/testthat/fixtures/season-transition-2024-to-2025"
+csv_dir <- tempfile("season-transition-snapshot-")
+dir.create(file.path(csv_dir, "RCode"), recursive = TRUE)
+
+# Copy the existing TeamList_2024.csv (script's input) into the temp RCode/.
+file.copy("RCode/TeamList_2024.csv",
+          file.path(csv_dir, "RCode", "TeamList_2024.csv"))
+
+probe_path <- tempfile(fileext = ".txt")
+
+with_mock_dir(fixture_dir, {
+  with_dir(csv_dir, {
+    with_envvar(list(SEASON_TRANSITION_ENGINE_PROBE = probe_path), {
+      # The script's main() reads commandArgs(trailingOnly = TRUE), so we
+      # invoke via system2 to get a real arg vector.
+      result <- system2(
+        "Rscript",
+        args = c(
+          file.path(getwd(), "..", "..", "..", "..", "scripts", "season_transition.R"),
+          "2024", "2025", "--non-interactive"
+        ),
+        env = c(
+          sprintf("RAPIDAPI_KEY=%s", Sys.getenv("RAPIDAPI_KEY")),
+          sprintf("SEASON_TRANSITION_ENGINE_PROBE=%s", probe_path)
+        ),
+        stdout = TRUE, stderr = TRUE
+      )
+      cat("Script exit status:", attr(result, "status") %||% 0L, "\n")
+      cat("--- script output ---\n")
+      cat(result, sep = "\n")
+      cat("\n--- end script output ---\n")
+    })
+  })
+})
+
+# Copy the resulting CSV into the fixture directory as the snapshot.
+src_csv <- file.path(csv_dir, "RCode", "TeamList_2025.csv")
+dst_csv <- file.path(fixture_dir, "TeamList_2025.csv.snapshot")
+stopifnot(file.exists(src_csv))
+file.copy(src_csv, dst_csv, overwrite = TRUE)
+cat("Snapshot saved to:", dst_csv, "\n")
+
+# Read the probe value and report it for inclusion in the test assertion.
+if (file.exists(probe_path)) {
+  cat("Probe value (record this in the snapshot test's assertion):",
+      readLines(probe_path)[1], "\n")
+} else {
+  cat("WARNING: probe file was not written. update_elos_for_match may not have been called.\n")
+}
+
+# Cleanup temp dir
+unlink(csv_dir, recursive = TRUE)
+unlink(probe_path)
+```
+
+**Note on path handling:** The `file.path(getwd(), "..", "..", "..", "..", "scripts", "season_transition.R")` resolves the script path *from inside the temp dir*. Adjust if your working directory at the time of running `_record.R` is not the project root (it should be). If unsure, replace with an absolute path.
+
+- [ ] **Step 3: Run the recording**
+
+From the project root:
+
+```bash
+cd "/Users/christophschwerdtfeger/Library/CloudStorage/Dropbox/Coding Projects/LeagueSimulator_Claude/League-Simulator-Update"
+export RAPIDAPI_KEY=your_key_here   # or however you load it
+Rscript tests/testthat/fixtures/season-transition-2024-to-2025/_record.R
+```
+
+Expected: cassette files appear under `tests/testthat/fixtures/season-transition-2024-to-2025/` (one sub-directory per host, JSON files inside). The script prints the probe value (likely `FALSE` since `season_transition.R` doesn't source the .cpp). The `TeamList_2025.csv.snapshot` is created.
+
+If the script fails partway (API error, missing key, etc.), fix and retry. Cassettes from a partial run are not safe to use — delete them and re-record.
+
+- [ ] **Step 4: Inspect cassettes for sensitive content**
+
+```bash
+grep -rni "rapidapi\|api.key\|x-rapidapi-key\|authorization" tests/testthat/fixtures/season-transition-2024-to-2025/
+```
+
+Expected: no matches. `httptest2` does not record request headers by default, but verify. If the key value (the actual key string) appears anywhere, **stop, scrub it, and verify the scrub before committing**.
+
+- [ ] **Step 5: Write the README**
+
+Create `tests/testthat/fixtures/season-transition-2024-to-2025/README.md`:
+
+```markdown
+# Season-transition cassette fixtures (2024 → 2025)
+
+Captured api-football response set + expected CSV snapshot for the
+end-to-end test at `tests/testthat/test-season-transition-csv-snapshot.R`.
+
+## Files
+
+- `<host>/<path>.json` — `httptest2` cassettes; each represents one HTTP GET
+  the season-transition script issues.
+- `TeamList_2025.csv.snapshot` — expected byte-exact output of the script.
+- `_record.R` — the recording harness. Not picked up by testthat.
+
+## Re-recording
+
+Required when:
+- the api-football response shape changes
+- `scripts/season_transition.R` issues new HTTP calls
+- the expected CSV output legitimately changes (e.g., new league rules)
+
+Procedure:
+
+```bash
+export RAPIDAPI_KEY=your_key_here
+Rscript tests/testthat/fixtures/season-transition-2024-to-2025/_record.R
+```
+
+Then inspect the captured files (`grep -rni rapidapi .` should return nothing)
+and `git add` the changes. Note the printed probe value and update the
+assertion in `test-season-transition-csv-snapshot.R` if it differs from what
+the test currently asserts.
+```
+
+- [ ] **Step 6: Commit fixtures**
+
+```bash
+git add tests/testthat/fixtures/season-transition-2024-to-2025/
+git commit -m "$(cat <<'EOF'
+test(#77): capture api-football cassettes for season-transition 2024->2025
+
+Recorded via httptest2::with_mock_dir against the live API (one-time).
+Re-record procedure documented in fixture README. Used by the upcoming
+end-to-end snapshot test.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: End-to-end CSV snapshot test
+
+**Files:**
+- Create: `tests/testthat/test-season-transition-csv-snapshot.R`
+
+This test runs `scripts/season_transition.R` in a real subprocess inside `withr::with_dir(temp_dir)`, plays back the cassettes captured in Task 4, and asserts:
+- subprocess exits 0
+- probe file written and contains the recorded value (gap #3)
+- resulting `RCode/TeamList_2025.csv` matches the snapshot byte-for-byte (gap #2)
+
+- [ ] **Step 1: Note the probe value from Task 4**
+
+Open `tests/testthat/fixtures/season-transition-2024-to-2025/_record.R` script's output (re-run if you didn't capture it). The printed line was:
+
+```
+Probe value (record this in the snapshot test's assertion): <FALSE or TRUE>
+```
+
+Use that literal in the test below in place of `"FALSE"` if it differs.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `tests/testthat/test-season-transition-csv-snapshot.R`:
+
+```r
+# End-to-end CSV snapshot regression net for the season-transition workflow.
+#
+# Runs scripts/season_transition.R in a subprocess inside a temp dir, plays
+# back api-football cassettes via httptest2, and asserts:
+#   (gap #2) the resulting RCode/TeamList_2025.csv matches the snapshot
+#   (gap #3) the engine-availability probe records the expected value
+#
+# Spec: docs/superpowers/specs/2026-05-03-season-transition-test-coverage-design.md
+
+library(testthat)
+library(httptest2)
+library(withr)
+
+test_that("season_transition.R 2024 -> 2025 produces byte-identical CSV", {
+  fixture_dir <- test_path("fixtures", "season-transition-2024-to-2025")
+  expected_csv <- file.path(fixture_dir, "TeamList_2025.csv.snapshot")
+  skip_if_not(file.exists(expected_csv),
+              "Snapshot fixture missing. Run _record.R to capture it.")
+
+  # Resolve project root (test runs with cwd = project root, but be defensive).
+  project_root <- if (file.exists("scripts/season_transition.R")) {
+    getwd()
+  } else if (file.exists("../../scripts/season_transition.R")) {
+    normalizePath("../..")
+  } else {
+    skip("Cannot locate project root with scripts/season_transition.R")
+  }
+
+  script_path <- file.path(project_root, "scripts", "season_transition.R")
+  source_csv  <- file.path(project_root, "RCode", "TeamList_2024.csv")
+  rcode_dir   <- file.path(project_root, "RCode")
+
+  # Stage a temp dir with a copy of RCode/TeamList_2024.csv (script's input)
+  # so the script can write TeamList_2025.csv into the temp RCode/ without
+  # touching the real one.
+  csv_dir <- tempfile("season-transition-snapshot-")
+  dir.create(file.path(csv_dir, "RCode"), recursive = TRUE)
+  file.copy(source_csv, file.path(csv_dir, "RCode", "TeamList_2024.csv"))
+
+  probe_path <- tempfile(fileext = ".txt")
+
+  on.exit({
+    unlink(csv_dir, recursive = TRUE)
+    unlink(probe_path)
+  }, add = TRUE)
+
+  # The script bails out without RAPIDAPI_KEY; a non-empty value is enough
+  # because httptest2 intercepts the actual GET.
+  test_env <- c(
+    "RAPIDAPI_KEY=test-mock-key-not-real",
+    sprintf("SEASON_TRANSITION_ENGINE_PROBE=%s", probe_path)
+  )
+
+  exit_status <- with_mock_dir(fixture_dir, {
+    with_dir(csv_dir, {
+      result <- system2(
+        "Rscript",
+        args = c(script_path, "2024", "2025", "--non-interactive"),
+        env = test_env,
+        stdout = TRUE, stderr = TRUE
+      )
+      attr(result, "status") %||% 0L
+    })
+  })
+
+  expect_equal(exit_status, 0L,
+               info = "season_transition.R subprocess must exit 0")
+
+  # Gap #3: probe assertion. Pinned literal — adjust if Task 4 recorded TRUE.
+  expect_true(file.exists(probe_path),
+              info = "probe file should be written by elo_aggregation.R")
+  engine_available <- readLines(probe_path)[1]
+  expect_true(engine_available %in% c("TRUE", "FALSE"),
+              info = "probe value must be TRUE or FALSE")
+  expect_equal(engine_available, "FALSE",
+    info = paste("Recorded current truth: scripts/season_transition.R does",
+                 "NOT source SpielNichtSimulieren.cpp, so the C++ primitive",
+                 "is unavailable in the script's process. If this changed,",
+                 "the Phase-2 PRD's plan must be revisited."))
+
+  # Gap #2: byte-identical CSV.
+  actual_csv <- file.path(csv_dir, "RCode", "TeamList_2025.csv")
+  expect_true(file.exists(actual_csv),
+              info = "season_transition.R must produce TeamList_2025.csv")
+
+  actual_bytes   <- readBin(actual_csv,   "raw", file.info(actual_csv)$size)
+  expected_bytes <- readBin(expected_csv, "raw", file.info(expected_csv)$size)
+
+  expect_equal(length(actual_bytes), length(expected_bytes),
+               info = "CSV byte-count drift; see fixture README to re-record")
+  expect_equal(actual_bytes, expected_bytes,
+               info = paste("CSV bytes differ from snapshot.",
+                            "If the change is intentional, re-record per",
+                            "tests/testthat/fixtures/season-transition-2024-to-2025/README.md."))
+})
+```
+
+- [ ] **Step 3: Run the test**
+
+```bash
+Rscript -e 'testthat::test_file("tests/testthat/test-season-transition-csv-snapshot.R")'
+```
+
+Expected: PASS. If the test fails:
+- **`exit_status != 0`** → check `result` (the captured stdout/stderr); the script likely hit a code path with no cassette. Re-record cassettes.
+- **probe value differs from `"FALSE"`** → `season_transition.R` *does* source the .cpp through some path you didn't expect. Update the literal in the assertion to `"TRUE"` and add a comment explaining where the .cpp gets sourced. This is a legitimate regression-net update, not a bug.
+- **CSV bytes differ** → either the recording captured a different code path than what runs in playback (re-record), or your local CSV write has locale/line-ending issues. Inspect the diff: `diff <(xxd $actual_csv) <(xxd $expected_csv) | head -30`. If line endings or whitespace differ, set `Sys.setlocale(...)` in the test (helper-test-setup.R already does this for unit tests but not for subprocesses).
+
+- [ ] **Step 4: Run the entire testthat suite to confirm no regressions**
+
+```bash
+Rscript -e 'testthat::test_dir("tests/testthat")' 2>&1 | tail -30
+```
+
+Expected: All previously-passing tests still pass. Two new test files contribute additional passes. Pre-existing failures (if any) unchanged in count.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/testthat/test-season-transition-csv-snapshot.R
+git commit -m "$(cat <<'EOF'
+test(#77): end-to-end CSV snapshot test for season-transition
+
+Runs scripts/season_transition.R in a subprocess via system2 inside
+withr::with_dir(temp_dir), plays back captured api-football cassettes
+via httptest2::with_mock_dir, and asserts:
+  - subprocess exits 0
+  - SEASON_TRANSITION_ENGINE_PROBE writes recorded engine availability
+  - resulting RCode/TeamList_2025.csv matches the snapshot byte-for-byte
+
+Closes the gap-#2 (CSV snapshot) and gap-#3 (Rcpp load-path verification)
+items from docs/superpowers/specs/2026-05-03-season-transition-test-coverage-design.md.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: Final verification
+
+- [ ] **Step 1: Run the full testthat suite one more time**
+
+```bash
+Rscript -e 'testthat::test_dir("tests/testthat")' 2>&1 | tail -40
+```
+
+Expected: All four artifacts (engine-selection 5 tests, snapshot 1 test) PASS. Pre-existing test counts unchanged. No new errors or warnings attributable to this work.
+
+- [ ] **Step 2: Verify production code parses**
+
+```bash
+Rscript -e 'invisible(parse("RCode/elo_aggregation.R")); cat("OK\n")'
+Rscript -e 'invisible(parse("scripts/season_transition.R")); cat("OK\n")'
+```
+
+Expected: `OK` from both.
+
+- [ ] **Step 3: Confirm probe is dormant in production conditions**
+
+Run a quick R session without the probe env var and confirm `update_elos_for_match` runs without writing any probe file:
+
+```bash
+Rscript -e '
+  Rcpp::sourceCpp("RCode/SpielNichtSimulieren.cpp")
+  source("RCode/elo_aggregation.R")
+  match <- data.frame(teams_home_id = 1L, teams_away_id = 2L, goals_home = 2, goals_away = 0)
+  elos  <- data.frame(TeamID = c(1L, 2L), CurrentELO = c(1500, 1500))
+  result <- update_elos_for_match(elos, match)
+  stopifnot(Sys.getenv("SEASON_TRANSITION_ENGINE_PROBE") == "")
+  cat("OK; probe inactive when env var unset.\n")
+'
+```
+
+Expected: `OK; probe inactive when env var unset.` and no error.
+
+- [ ] **Step 4: Push to origin (optional, per user policy)**
+
+```bash
+git log --oneline origin/main..HEAD
+```
+
+Verify the four (or so) new commits are on the branch. Do NOT push without explicit user instruction — Christoph's branch-completion preference is push+PR, but check via the saved memory before acting.
+
+---
+
+## Self-Review Notes (for the executing engineer)
+
+After completing all tasks, run a quick mental check:
+
+1. **Did the `_record.R` script need adjustment?** The path-walking with `..` is brittle; if you fixed it, document the actual approach in the fixture README so re-recording works for the next person.
+2. **Did the C++/R agreement test (Task 2 test 3) reveal a divergence?** If yes, update the comment at the top of the test file and surface the finding to the user — it directly affects the Phase-2 PRD's Option A vs Option B branch.
+3. **Is the snapshot CSV in git LFS-territory size?** Bundesliga + 2. Bundesliga + 3. Liga = ~60 teams × 4 columns. Should be < 5 KB. If something is dramatically larger, the fixture or snapshot captured something unintended (e.g., the script's stderr leaked into stdout).
+4. **Is the cassette directory size reasonable?** Total < 1 MB. If larger, the script issued more API calls than expected (perhaps a 3-Liga edge case); inspect.
+
+If any item above produces a finding, surface it to the user before declaring the plan complete.

--- a/docs/superpowers/plans/2026-07-02-codebase-review-findings.md
+++ b/docs/superpowers/plans/2026-07-02-codebase-review-findings.md
@@ -1,0 +1,1620 @@
+# Codebase Review Findings Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement all actionable findings from the 2026-07-02 three-dimension codebase review (security, efficiency, usability) in one coherent branch/PR.
+
+**Architecture:** Small, independent fixes across four subsystems: Rust simulation server (input validation, hot-path performance), R orchestration (API-call gating, vectorization, secret handling), Shiny app (graceful degradation, stale-data warning), and infrastructure (Docker hardening + layer caching, CI action pinning, docs). One branch, one PR — the Docker changes (non-root user + new runtime stage) interact and must be CI-validated together.
+
+**Tech Stack:** R 4.3+ (testthat, httr, jsonlite, shiny), Rust (axum 0.8, rayon, statrs), Docker multi-stage builds, GitHub Actions.
+
+## Global Constraints
+
+- Branch: `fix/codebase-review-2026-07` off `main`. One PR at the end. Conventional-commit messages (`fix:`, `perf:`, `docs:`, `chore:`).
+- NEVER commit the string `3EBFA2C60C1438DAAA98FE4C0CAEC9AC` in any new file (it is the compromised token being removed). This plan file references it only descriptively.
+- R code style: repo has `.lintr`; run `Rscript -e 'lintr::lint("<file>")'` on every touched R file, zero new findings.
+- Rust: `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` must pass in `league-simulator-rust/` after every Rust task.
+- R tests are run per-file: `Rscript -e 'testthat::test_file("tests/testthat/<file>")'` from the repo root.
+- Behavior-identical refactors (Tasks 8, 9) need a green run of their existing test file BEFORE and AFTER the change.
+- Production simulation behavior (probability outputs) must remain statistically identical; exact RNG-stream equality is NOT required for Task 5/6 (documented there).
+- The operator (user) rotates the ShinyApps.io token out-of-band and sets `SHINYAPPS_IO_TOKEN` in `.env`. Code must hard-fail with an actionable message when it is missing.
+
+## Consciously NOT implemented (from review, with reasons)
+
+- `rust_integration.R` lapply serialization & Shiny `apply()` caching — review itself assessed "kein relevanter Effekt".
+- `calculate_table` per-call `Vec<TeamStanding>` allocation — 18–20-element alloc; fixing it churns a public API used by lib + tests for negligible gain.
+- Poisson binary-search upper bound `lambda*3+20` — obsolete: after Task 5 the binary search only runs for lambda ≥ 10, which never occurs in production (lambda ≈ 0.6–2.5).
+- app.R German/English naming consistency — pure style churn, no user-visible effect.
+
+---
+
+### Task 1: Remove hardcoded ShinyApps.io token
+
+**Files:**
+- Modify: `RCode/updateShiny.R:26-30`
+- Modify: `docker-compose.yml:9`
+- Test: `tests/testthat/test-updateShiny-env.R` (create)
+
+**Interfaces:**
+- Produces: `updateShiny()` now requires env vars `SHINYAPPS_IO_TOKEN` and `SHINYAPPS_IO_SECRET`; reads optional `SHINYAPPS_IO_NAME` (default `"chrisschwer"`). Task 12 later edits the `appFiles` line in this same file.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/testthat/test-updateShiny-env.R`:
+
+```r
+# updateShiny must hard-fail with an actionable message when ShinyApps.io
+# credentials are missing from the environment (no hardcoded fallbacks).
+
+source_updateShiny <- function() {
+  source(test_path("..", "..", "RCode", "updateShiny.R"), local = TRUE)
+  environment()$updateShiny
+}
+
+test_that("updateShiny stops when SHINYAPPS_IO_TOKEN is not set", {
+  updateShiny <- source_updateShiny()
+  withr::local_envvar(c(SHINYAPPS_IO_TOKEN = "", SHINYAPPS_IO_SECRET = "dummy"))
+  expect_error(
+    updateShiny(NULL, NULL, NULL, directory = tempdir()),
+    "SHINYAPPS_IO_TOKEN"
+  )
+})
+
+test_that("updateShiny stops when SHINYAPPS_IO_SECRET is not set", {
+  updateShiny <- source_updateShiny()
+  withr::local_envvar(c(SHINYAPPS_IO_TOKEN = "dummy", SHINYAPPS_IO_SECRET = ""))
+  expect_error(
+    updateShiny(NULL, NULL, NULL, directory = tempdir()),
+    "SHINYAPPS_IO_SECRET"
+  )
+})
+```
+
+If `withr` is unavailable in the local test setup, use `old <- Sys.getenv(...); Sys.setenv(...); on.exit(...)` instead — check how existing tests (e.g. `tests/testthat/test-rust-required.R`) manage env vars and follow that pattern.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `Rscript -e 'testthat::test_file("tests/testthat/test-updateShiny-env.R")'`
+Expected: FAIL (no error raised for missing token — current code hardcodes it).
+
+- [ ] **Step 3: Implement**
+
+In `RCode/updateShiny.R`, insert env validation as the FIRST statements inside the function body (before the `required_packages` loop, so the check needs no packages), and replace the hardcoded credentials block:
+
+```r
+updateShiny <- function(Ergebnis, Ergebnis2, Ergebnis3,
+                        Ergebnis3_Aufstieg = Ergebnis3,
+                        directory = file.path(
+                          "/Users/christophschwerdtfeger/Library/CloudStorage/Dropbox-CSDataScience",
+                          "Christoph Schwerdtfeger/Coding Projects/LeagueSimulator_Claude",
+                          "League-Simulator-Update/ShinyApp"
+                        ),
+                        forceUpdate = TRUE) {
+  account_name <- Sys.getenv("SHINYAPPS_IO_NAME", "chrisschwer")
+  account_token <- Sys.getenv("SHINYAPPS_IO_TOKEN")
+  account_secret <- Sys.getenv("SHINYAPPS_IO_SECRET")
+
+  if (account_token == "") {
+    stop("ERROR: SHINYAPPS_IO_TOKEN environment variable not set")
+  }
+  if (account_secret == "") {
+    stop("ERROR: SHINYAPPS_IO_SECRET environment variable not set")
+  }
+```
+
+Then DELETE the old lines 26-28 (`account_name <- "chrisschwer"`, the hardcoded `account_token <- "..."`, and the old `account_secret <- Sys.getenv(...)`). The `rsconnect::setAccountInfo(...)` call stays unchanged.
+
+In `docker-compose.yml` line 9, remove the fallback default:
+
+```yaml
+      - SHINYAPPS_IO_TOKEN=${SHINYAPPS_IO_TOKEN}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `Rscript -e 'testthat::test_file("tests/testthat/test-updateShiny-env.R")'`
+Expected: PASS (2 tests).
+
+Also verify the token string is gone from the working tree:
+Run: `grep -rn "3EBFA2C60C1438DAAA98FE4C0CAEC9AC" --exclude-dir=.git . || echo CLEAN`
+Expected: only this plan file (descriptive mention) — no code/config hits. If the plan file is the sole hit: OK.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add RCode/updateShiny.R docker-compose.yml tests/testthat/test-updateShiny-env.R
+git commit -m "fix(security): read ShinyApps.io token from environment, remove hardcoded credential"
+```
+
+---
+
+### Task 2: Rust API input validation, iterations cap, body limit
+
+**Files:**
+- Modify: `league-simulator-rust/src/api/handlers.rs`
+- Modify: `league-simulator-rust/src/api/mod.rs`
+- Modify: `league-simulator-rust/Cargo.toml` (remove `tower-http` if unused after CORS removal)
+- Test: `league-simulator-rust/src/api/tests.rs`
+
+**Interfaces:**
+- Produces: `/simulate` and `/simulate/batch` return `400 Bad Request` with a plain-text body explaining the validation failure. Success responses unchanged. `MAX_ITERATIONS = 100_000`.
+
+- [ ] **Step 1: Read `league-simulator-rust/src/api/tests.rs`** to learn the existing oneshot-test pattern (imports, helper for building requests). Reuse it exactly.
+
+- [ ] **Step 2: Write failing tests** (append to `src/api/tests.rs`, adapting imports to the existing pattern):
+
+```rust
+#[tokio::test]
+async fn simulate_rejects_team_index_zero() {
+    // team index 0 previously underflowed to usize::MAX and aborted the process
+    let body = serde_json::json!({
+        "schedule": [[0, 2, null, null]],
+        "elo_values": [1500.0, 1500.0]
+    });
+    let response = post_json("/simulate", body).await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn simulate_rejects_null_team_index() {
+    let body = serde_json::json!({
+        "schedule": [[null, 2, null, null]],
+        "elo_values": [1500.0, 1500.0]
+    });
+    let response = post_json("/simulate", body).await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn simulate_rejects_out_of_range_team_index() {
+    let body = serde_json::json!({
+        "schedule": [[1, 3, null, null]],
+        "elo_values": [1500.0, 1500.0]
+    });
+    let response = post_json("/simulate", body).await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn simulate_rejects_excessive_iterations() {
+    let body = serde_json::json!({
+        "schedule": [[1, 2, null, null]],
+        "elo_values": [1500.0, 1500.0],
+        "iterations": 100_000_000
+    });
+    let response = post_json("/simulate", body).await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn simulate_rejects_mismatched_adjustment_length() {
+    let body = serde_json::json!({
+        "schedule": [[1, 2, null, null]],
+        "elo_values": [1500.0, 1500.0],
+        "adj_points": [0, 0, 0]
+    });
+    let response = post_json("/simulate", body).await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+```
+
+If the existing tests have no `post_json` helper, write one following their exact request-building style.
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cd league-simulator-rust && cargo test api`
+Expected: new tests FAIL (some may abort/panic — that is the bug being fixed).
+
+- [ ] **Step 4: Implement validation in `handlers.rs`**
+
+Add near the top of the file:
+
+```rust
+/// Server-side ceiling on Monte Carlo iterations (production uses 10,000).
+const MAX_ITERATIONS: usize = 100_000;
+
+fn validate_request(payload: &SimulateRequest) -> Result<(), String> {
+    if payload.schedule.is_empty() {
+        return Err("schedule must not be empty".to_string());
+    }
+    let number_teams = payload.elo_values.len();
+    if number_teams == 0 {
+        return Err("elo_values must not be empty".to_string());
+    }
+    if let Some(iterations) = payload.iterations {
+        if iterations == 0 || iterations > MAX_ITERATIONS {
+            return Err(format!(
+                "iterations must be between 1 and {}, got {}",
+                MAX_ITERATIONS, iterations
+            ));
+        }
+    }
+    for (i, row) in payload.schedule.iter().enumerate() {
+        for (name, value) in [("team_home", row[0]), ("team_away", row[1])] {
+            match value {
+                Some(v) if v >= 1 && (v as usize) <= number_teams => {}
+                Some(v) => {
+                    return Err(format!(
+                        "schedule row {}: {} index {} out of range 1..={}",
+                        i, name, v, number_teams
+                    ))
+                }
+                None => return Err(format!("schedule row {}: {} must not be null", i, name)),
+            }
+        }
+    }
+    for (name, adj) in [
+        ("adj_points", &payload.adj_points),
+        ("adj_goals", &payload.adj_goals),
+        ("adj_goals_against", &payload.adj_goals_against),
+        ("adj_goal_diff", &payload.adj_goal_diff),
+    ] {
+        if let Some(v) = adj {
+            if v.len() != number_teams {
+                return Err(format!(
+                    "{} has length {}, expected {} (one per team)",
+                    name,
+                    v.len(),
+                    number_teams
+                ));
+            }
+        }
+    }
+    Ok(())
+}
+```
+
+Change `simulate_league`'s signature and body:
+
+```rust
+pub async fn simulate_league(
+    Json(payload): Json<SimulateRequest>,
+) -> Result<Json<SimulateResponse>, (StatusCode, String)> {
+    let start = std::time::Instant::now();
+
+    validate_request(&payload).map_err(|e| (StatusCode::BAD_REQUEST, e))?;
+
+    let number_teams = payload.elo_values.len();
+```
+
+Delete the two old ad-hoc checks (empty schedule / zero teams — now inside `validate_request`). The match conversion becomes panic-free because validation guarantees `Some(v)` with `1 <= v <= number_teams`:
+
+```rust
+    let matches: Vec<Match> = payload
+        .schedule
+        .iter()
+        .map(|row| Match {
+            // Validated above: indices are Some and within 1..=number_teams.
+            // R uses 1-indexed, Rust uses 0-indexed.
+            team_home: row[0].unwrap() as usize - 1,
+            team_away: row[1].unwrap() as usize - 1,
+            goals_home: row[2],
+            goals_away: row[3],
+        })
+        .collect();
+```
+
+Propagate errors through the batch path — `simulate_league_internal` must no longer swallow failures into empty responses:
+
+```rust
+async fn simulate_league_internal(
+    request: SimulateRequest,
+) -> Result<SimulateResponse, (StatusCode, String)> {
+    simulate_league(Json(request)).await.map(|Json(r)| r)
+}
+```
+
+And in `simulate_batch`, adjust the collection loop:
+
+```rust
+    for task in tasks {
+        match task.await {
+            Ok((name, Ok(response))) => {
+                results.push(LeagueResult { name, response });
+            }
+            Ok((name, Err((status, msg)))) => {
+                return Err((status, format!("league '{}': {}", name, msg)));
+            }
+            Err(_) => {
+                return Err((
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "batch task panicked".to_string(),
+                ));
+            }
+        }
+    }
+```
+
+`simulate_batch`'s signature becomes `Result<Json<BatchSimulateResponse>, (StatusCode, String)>`.
+
+- [ ] **Step 5: Add body limit, drop permissive CORS in `mod.rs`**
+
+CORS is a browser mechanism; the only clients are R/httr and curl, which ignore it — the permissive layer adds attack surface for nothing. Replace `mod.rs` router setup:
+
+```rust
+use axum::{
+    extract::DefaultBodyLimit,
+    routing::{get, post},
+    Router,
+};
+
+pub fn create_router() -> Router {
+    Router::new()
+        .route("/health", get(handlers::health_check))
+        .route("/simulate", post(handlers::simulate_league))
+        .route("/simulate/batch", post(handlers::simulate_batch))
+        // Payloads are ~306 fixture rows (<100 KB); 2 MB is generous headroom.
+        .layer(DefaultBodyLimit::max(2 * 1024 * 1024))
+}
+```
+
+Remove the `Method`/`tower_http::cors` imports. Then check whether `tower-http` is still used anywhere: `grep -rn "tower_http" league-simulator-rust/src/`. If this was the only use, remove the `tower-http` dependency line from `Cargo.toml`.
+
+- [ ] **Step 6: Run tests**
+
+Run: `cd league-simulator-rust && cargo test && cargo fmt --check && cargo clippy -- -D warnings`
+Expected: all PASS, no warnings. If existing tests asserted plain `StatusCode` error returns, update them to the new `(StatusCode, String)` shape.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add league-simulator-rust
+git commit -m "fix(security): validate simulation requests, cap iterations, limit body size
+
+A team index of 0 or null underflowed to usize::MAX and aborted the
+whole process (panic=abort) — a one-request remote DoS. Requests are
+now validated up front and rejected with 400 + reason. Also removes
+the permissive CORS layer (no browser clients exist) and caps request
+bodies at 2 MB."
+```
+
+---
+
+### Task 3: Bind Rust port to localhost, stop logging API-key prefix
+
+**Files:**
+- Modify: `docker-compose.yml:15`
+- Modify: `docker-start.sh:102`
+
+- [ ] **Step 1: Implement**
+
+`docker-compose.yml` line 15 (the integrated service; leave the debug-profile `rust-simulator` service's mapping as is, or apply the same binding there too — do both for consistency):
+
+```yaml
+    ports:
+      - "127.0.0.1:8081:8080"  # Rust API, host-local only (monitoring via curl on the host)
+```
+
+`docker-start.sh` line 102 — replace:
+
+```sh
+echo "API Key: $(echo $RAPIDAPI_KEY | cut -c1-10)..."
+```
+
+with:
+
+```sh
+echo "API Key: $([ -n "$RAPIDAPI_KEY" ] && echo "SET" || echo "NOT SET")"
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `docker compose config > /dev/null && echo OK` (validates YAML)
+Run: `sh -n docker-start.sh && echo OK` (validates shell syntax)
+Expected: `OK` twice.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docker-compose.yml docker-start.sh
+git commit -m "fix(security): bind Rust API to localhost on host, stop logging API-key prefix"
+```
+
+---
+
+### Task 4: Pin GitHub Actions to commit SHAs
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+- Modify: `.github/workflows/codeql.yml`
+
+- [ ] **Step 1: Resolve each action tag to its commit SHA**
+
+For every `uses:` entry (`actions/checkout@v7`, `dtolnay/rust-toolchain@stable`, `actions/cache@v6`, `r-lib/actions/setup-r@v2`, `docker/setup-buildx-action@v4`, `docker/login-action@v4`, `docker/build-push-action@v7`, `actions/upload-artifact@v7`, `actions/download-artifact@v8`, `github/codeql-action/init@v4`, `github/codeql-action/analyze@v4`), resolve the SHA:
+
+```bash
+gh api repos/actions/checkout/git/ref/tags/v7 --jq '.object.sha'
+# If the tag object is annotated, dereference:
+gh api repos/actions/checkout/git/tags/<sha-from-above> --jq '.object.sha' 2>/dev/null || true
+```
+
+For branch-style refs (`dtolnay/rust-toolchain@stable`): `gh api repos/dtolnay/rust-toolchain/commits/stable --jq '.sha'`.
+For subpath actions (`r-lib/actions/setup-r@v2`, `github/codeql-action/init@v4`): resolve the SHA of the REPO (`r-lib/actions`, `github/codeql-action`) at that tag; the subpath stays in the `uses:` string.
+
+- [ ] **Step 2: Rewrite every `uses:` line** to the form:
+
+```yaml
+        uses: actions/checkout@<full-40-char-sha>  # v7
+```
+
+(keep the human-readable tag as a trailing comment).
+
+- [ ] **Step 3: Document the fork-PR login guard**
+
+Above the `Log in to Docker Hub (read-only for cache)` step in `ci.yml` (line ~94), extend the existing setup with an explicit comment:
+
+```yaml
+      # Fork/Dependabot PRs get empty secrets from GitHub, so this step is
+      # skipped there by the env guard below — they build without registry
+      # login and can only READ the public build cache. Do not remove the guard.
+```
+
+- [ ] **Step 4: Verify**
+
+Run: `grep -n "uses:" .github/workflows/ci.yml .github/workflows/codeql.yml`
+Expected: every line matches `@[0-9a-f]{40}  # v...` (except none remain on bare tags).
+Optionally: `actionlint` if installed; otherwise rely on CI.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/ci.yml .github/workflows/codeql.yml
+git commit -m "chore(security): pin GitHub Actions to commit SHAs"
+```
+
+---
+
+### Task 5: Fast Poisson quantile in the simulation hot path
+
+**Files:**
+- Modify: `league-simulator-rust/src/simulation/match_sim.rs`
+- Delete: `league-simulator-rust/src/simulation/match_sim_fixed.rs` (dead code, not even declared in `mod.rs`)
+
+**Interfaces:**
+- Produces: `poisson_quantile_direct(p: f64, lambda: f64) -> f64` (public, in `match_sim.rs`). `poisson_quantile` dispatches: direct for `lambda < 10`, binary search otherwise. `simulate_match` / `simulate_match_random` signatures unchanged.
+
+**Note on determinism:** the direct method computes the same qpois semantics (smallest k with `P(X ≤ k) ≥ p`) via iterative summation instead of gamma-function CDFs. Float rounding could theoretically differ at exact CDF boundaries (~1e-15 measure); statistically irrelevant for Monte Carlo. The equivalence test below pins agreement across a dense grid.
+
+- [ ] **Step 1: Write failing tests** (append `#[cfg(test)] mod tests` inside `match_sim.rs`, or extend if one exists):
+
+```rust
+#[cfg(test)]
+mod poisson_tests {
+    use super::*;
+
+    #[test]
+    fn direct_quantile_matches_r_qpois() {
+        // Expected values computed with R: qpois(p, 1.3218390805)
+        let lambda = 1.3218390805;
+        let cases = [
+            (0.1, 0.0),
+            (0.2, 0.0),
+            (0.3, 1.0),
+            (0.5, 1.0),
+            (0.7, 2.0),
+            (0.9, 3.0),
+        ];
+        for (p, expected) in cases {
+            assert_eq!(
+                poisson_quantile_direct(p, lambda),
+                expected,
+                "qpois({}, {})",
+                p,
+                lambda
+            );
+        }
+    }
+
+    #[test]
+    fn direct_quantile_agrees_with_binary_search() {
+        for &lambda in &[0.1, 0.5, 1.0, 1.3218390805, 2.0, 5.0, 9.9] {
+            let mut p = 0.001;
+            while p < 0.999 {
+                assert_eq!(
+                    poisson_quantile_direct(p, lambda),
+                    poisson_quantile_statrs(p, lambda),
+                    "divergence at p={}, lambda={}",
+                    p,
+                    lambda
+                );
+                p += 0.001;
+            }
+        }
+    }
+
+    #[test]
+    fn direct_quantile_edge_cases() {
+        assert_eq!(poisson_quantile_direct(0.0, 1.5), 0.0);
+        assert_eq!(poisson_quantile_direct(-0.1, 1.5), 0.0);
+        assert_eq!(poisson_quantile_direct(1.0, 1.5), f64::INFINITY);
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd league-simulator-rust && cargo test poisson`
+Expected: COMPILE ERROR — `poisson_quantile_direct` does not exist.
+
+- [ ] **Step 3: Implement in `match_sim.rs`**
+
+Replace the `poisson_quantile` dispatcher and add the direct method:
+
+```rust
+/// Calculate the quantile of a Poisson distribution.
+/// Matches R's qpois: smallest integer k with P(X <= k) >= p.
+fn poisson_quantile(p: f64, lambda: f64) -> f64 {
+    // Production lambdas are ~0.6-2.5 (ELO-derived goal averages), so the
+    // O(k) direct summation terminates after a handful of multiplications
+    // instead of ~5 regularized-gamma CDF evaluations per draw.
+    if lambda < 10.0 {
+        poisson_quantile_direct(p, lambda)
+    } else {
+        poisson_quantile_statrs(p, lambda)
+    }
+}
+
+/// Iterative CDF summation: P(X = k) = P(X = k-1) * lambda / k.
+pub fn poisson_quantile_direct(p: f64, lambda: f64) -> f64 {
+    if p <= 0.0 {
+        return 0.0;
+    }
+    if p >= 1.0 {
+        return f64::INFINITY;
+    }
+    let mut k: u64 = 0;
+    let mut prob = (-lambda).exp(); // P(X = 0)
+    let mut cumulative = prob;
+    while cumulative < p && k < 1000 {
+        k += 1;
+        prob *= lambda / (k as f64);
+        cumulative += prob;
+    }
+    k as f64
+}
+```
+
+Keep `poisson_quantile_statrs` unchanged (still used for lambda ≥ 10 and by the equivalence test).
+
+Delete `league-simulator-rust/src/simulation/match_sim_fixed.rs` (`git rm`). It was never declared in `simulation/mod.rs` — verify with `grep -rn "match_sim_fixed" league-simulator-rust/src/` → only the file itself.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd league-simulator-rust && cargo test && cargo fmt --check && cargo clippy -- -D warnings`
+Expected: all PASS including existing simulation/API tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A league-simulator-rust/src/simulation
+git commit -m "perf: direct Poisson quantile for small lambda, remove dead match_sim_fixed.rs"
+```
+
+---
+
+### Task 6: Lock-free Monte Carlo aggregation + per-thread buffer reuse
+
+**Files:**
+- Modify: `league-simulator-rust/src/simulation/season.rs`
+- Modify: `league-simulator-rust/src/monte_carlo/mod.rs`
+
+**Interfaces:**
+- Consumes: `calculate_table` (unchanged).
+- Produces: `simulate_season_in_place(matches: &mut [Match], elos: &mut [f64], mod_factor: f64, home_advantage: f64, tore_slope: f64, tore_intercept: f64, rng: &mut R)` in `season.rs`. Existing `simulate_season` / `process_season` keep their signatures (now thin wrappers).
+
+- [ ] **Step 1: Baseline** — run `cd league-simulator-rust && cargo test` → all green (existing determinism/seed tests are the safety net; count aggregation is commutative, so fold/reduce ordering cannot change results).
+
+- [ ] **Step 2: Refactor `season.rs`**
+
+Extract the loop body of `simulate_season` into an in-place variant; `simulate_season` becomes a wrapper:
+
+```rust
+/// In-place variant: operates on caller-owned buffers so Monte Carlo
+/// iterations can reuse allocations instead of cloning per iteration.
+pub fn simulate_season_in_place<R: Rng>(
+    matches: &mut [Match],
+    elos: &mut [f64],
+    mod_factor: f64,
+    home_advantage: f64,
+    tore_slope: f64,
+    tore_intercept: f64,
+    rng: &mut R,
+) {
+    for match_data in matches.iter_mut() {
+        let team_home = match_data.team_home;
+        let team_away = match_data.team_away;
+
+        if match_data.goals_home.is_none() {
+            let result = simulate_match_random(
+                elos[team_home],
+                elos[team_away],
+                mod_factor,
+                home_advantage,
+                tore_slope,
+                tore_intercept,
+                rng,
+            );
+            match_data.goals_home = Some(result.goals_home);
+            match_data.goals_away = Some(result.goals_away);
+            elos[team_home] = result.new_elo_home;
+            elos[team_away] = result.new_elo_away;
+        } else {
+            let params = EloParams {
+                elo_home: elos[team_home],
+                elo_away: elos[team_away],
+                goals_home: match_data.goals_home.unwrap(),
+                goals_away: match_data.goals_away.unwrap(),
+                mod_factor,
+                home_advantage,
+            };
+            let result = calculate_elo_change(&params);
+            elos[team_home] = result.new_elo_home;
+            elos[team_away] = result.new_elo_away;
+        }
+    }
+}
+
+pub fn simulate_season<R: Rng>(
+    season: &Season,
+    mod_factor: f64,
+    home_advantage: f64,
+    tore_slope: f64,
+    tore_intercept: f64,
+    rng: &mut R,
+) -> (Vec<Match>, Vec<f64>) {
+    let mut matches = season.matches.clone();
+    let mut elos = season.team_elos.clone();
+    simulate_season_in_place(
+        &mut matches,
+        &mut elos,
+        mod_factor,
+        home_advantage,
+        tore_slope,
+        tore_intercept,
+        rng,
+    );
+    (matches, elos)
+}
+```
+
+(Match the generic bounds the current code compiles with — if `simulate_match_random` needs `R: Rng + RngExt`, mirror that.)
+
+- [ ] **Step 3: Rewrite aggregation in `monte_carlo/mod.rs`**
+
+Replace the `Mutex`-based section of `run_monte_carlo_simulation_with_seeds` (keep everything from `// Convert counts to probabilities` onward, adapting it to read from plain `Vec<Vec<usize>>`):
+
+```rust
+use crate::simulation::{calculate_table, simulate_season_in_place};
+
+    let n_teams = season.number_teams;
+
+    // Per-thread fold state: reusable simulation buffers + local counts.
+    // No locks; rayon reduces the per-thread counts at the end (addition is
+    // commutative, so scheduling order cannot affect the result).
+    struct IterState {
+        matches: Vec<crate::models::Match>,
+        elos: Vec<f64>,
+        counts: Vec<Vec<usize>>,
+    }
+
+    let position_counts: Vec<Vec<usize>> = seeds
+        .par_iter()
+        .fold(
+            || IterState {
+                matches: Vec::with_capacity(season.matches.len()),
+                elos: Vec::with_capacity(n_teams),
+                counts: vec![vec![0usize; n_teams]; n_teams],
+            },
+            |mut state, &seed| {
+                let mut rng = StdRng::seed_from_u64(seed);
+
+                state.matches.clear();
+                state.matches.extend_from_slice(&season.matches);
+                state.elos.clear();
+                state.elos.extend_from_slice(&season.team_elos);
+
+                simulate_season_in_place(
+                    &mut state.matches,
+                    &mut state.elos,
+                    params.mod_factor,
+                    params.home_advantage,
+                    params.tore_slope,
+                    params.tore_intercept,
+                    &mut rng,
+                );
+
+                let table = calculate_table(
+                    &state.matches,
+                    n_teams,
+                    params.adj_points.as_deref(),
+                    params.adj_goals.as_deref(),
+                    params.adj_goals_against.as_deref(),
+                    params.adj_goal_diff.as_deref(),
+                );
+
+                for standing in &table.standings {
+                    state.counts[standing.team_id][standing.position - 1] += 1;
+                }
+                state
+            },
+        )
+        .map(|state| state.counts)
+        .reduce(
+            || vec![vec![0usize; n_teams]; n_teams],
+            |mut a, b| {
+                for (row_a, row_b) in a.iter_mut().zip(b) {
+                    for (cell_a, cell_b) in row_a.iter_mut().zip(row_b) {
+                        *cell_a += cell_b;
+                    }
+                }
+                a
+            },
+        );
+```
+
+Remove `use std::sync::Mutex;` and `use crate::simulation::process_season;` if no longer referenced (`process_season` stays in `season.rs` for external callers/tests — check `grep -rn "process_season" league-simulator-rust/src/` before removing the import only). Requires `Match: Clone` (check `models`; derive `Clone` if missing). Adjust the probability-conversion loop to index `position_counts[team_id][position]` directly without locking.
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd league-simulator-rust && cargo test && cargo fmt --check && cargo clippy -- -D warnings`
+Expected: all PASS — especially the seeded-determinism test in `monte_carlo/tests.rs`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add league-simulator-rust/src
+git commit -m "perf: lock-free rayon fold/reduce aggregation and buffer reuse in Monte Carlo loop"
+```
+
+---
+
+### Task 7: Dockerfile — dependency-layer caching, slim runtime stage, non-root user
+
+**Files:**
+- Modify: `Dockerfile`
+
+**Interfaces:**
+- Consumes: `docker-start.sh` (unchanged), Rust binary path `/usr/local/bin/league-simulator-rust`.
+- Produces: final image runs as user `appuser` (uid 1001); R site-library at `/usr/local/lib/R/site-library` copied into a toolchain-free runtime stage.
+
+- [ ] **Step 1: Rewrite `Dockerfile`**
+
+```dockerfile
+# Integrated League Simulator with Rust Engine
+# Stage 1: Rust binary | Stage 2: R build (compilers) | Stage 3: slim runtime
+
+# ---- Stage 1: Build Rust binary ----
+FROM rust:1.96-alpine AS rust-builder
+
+RUN apk add --no-cache musl-dev
+
+WORKDIR /build
+
+# Dependency layer: build with a dummy main so crate compilation is cached
+# and re-runs only when Cargo.toml/Cargo.lock change, not on every code edit.
+COPY league-simulator-rust/Cargo.toml league-simulator-rust/Cargo.lock ./
+RUN mkdir src && echo 'fn main() {}' > src/main.rs \
+    && cargo build --release \
+    && rm -rf src target/release/league-simulator-rust* target/release/deps/league_simulator_rust*
+
+COPY league-simulator-rust/src/ ./src/
+COPY league-simulator-rust/test_data/ ./test_data/
+RUN cargo build --release && strip target/release/league-simulator-rust
+
+# ---- Stage 2: Build R library (needs compilers for source packages) ----
+FROM rocker/r-ver:4.6.1 AS r-builder
+
+RUN apt-get update && apt-get install -y \
+    libcurl4-openssl-dev \
+    libssl-dev \
+    libxml2-dev \
+    tzdata \
+    build-essential \
+    cmake \
+    libuv1-dev \
+    libfontconfig1-dev \
+    libcairo2-dev \
+    libfreetype6-dev \
+    libpng-dev \
+    libtiff5-dev \
+    libjpeg-dev \
+    && rm -rf /var/lib/apt/lists/*
+```
+
+Keep the three existing `RUN R --slave ...` package-install blocks and the `COPY packagelist.txt /tmp/` EXACTLY as they are today (they run in this stage unchanged).
+
+Then add the runtime stage:
+
+```dockerfile
+# ---- Stage 3: Runtime (no compilers, non-root) ----
+FROM rocker/r-ver:4.6.1
+
+# Runtime (non -dev) libraries for the compiled R packages + curl for healthchecks
+RUN apt-get update && apt-get install -y \
+    libcurl4 \
+    libssl3 \
+    libxml2 \
+    curl \
+    tzdata \
+    libuv1 \
+    libfontconfig1 \
+    libcairo2 \
+    libfreetype6 \
+    libpng16-16 \
+    libtiff6 \
+    libjpeg62-turbo \
+    && rm -rf /var/lib/apt/lists/*
+
+# Compiled R packages from the build stage
+COPY --from=r-builder /usr/local/lib/R/site-library /usr/local/lib/R/site-library
+
+# Rust binary
+COPY --from=rust-builder /build/target/release/league-simulator-rust /usr/local/bin/league-simulator-rust
+
+WORKDIR /app
+RUN mkdir -p /app/RCode /app/ShinyApp/data
+
+COPY RCode/ ./RCode/
+COPY ShinyApp/ ./ShinyApp/
+COPY docker-start.sh /app/start.sh
+RUN chmod +x /app/start.sh
+
+# Run as non-root; scheduler writes ShinyApp/data and rsconnect config in $HOME
+RUN useradd --system --create-home --uid 1001 appuser \
+    && chown -R appuser:appuser /app
+USER appuser
+
+ENV RUST_API_URL=http://localhost:8080
+ENV SEASON=2025
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s \
+    CMD curl -f http://localhost:8080/health || exit 1
+
+CMD ["/app/start.sh"]
+```
+
+Notes for the implementer:
+- If `league-simulator-rust/Cargo.lock` is not committed (`ls league-simulator-rust/Cargo.lock`), generate it (`cd league-simulator-rust && cargo generate-lockfile`) and commit it — reproducible builds need it anyway.
+- Runtime lib names (`libssl3`, `libtiff6`, `libjpeg62-turbo`, `libpng16-16`) must match the Debian release under `rocker/r-ver:4.6.1`. Verify inside the image: `docker run --rm rocker/r-ver:4.6.1 bash -c "apt-cache policy libssl3 libtiff6 libjpeg62-turbo libpng16-16 libuv1"` and adjust names if the release differs (e.g. `libtiff5` on older Debian).
+
+- [ ] **Step 2: Build and verify (slow, ~20 min)**
+
+```bash
+docker build -t league-simulator:review-test .
+# Non-root?
+docker run --rm league-simulator:review-test id -u        # expected: 1001
+# All runtime-critical R packages load without compilers?
+docker run --rm league-simulator:review-test Rscript -e \
+  'for (p in c("httr","jsonlite","dplyr","tidyr","shiny","rsconnect","httpuv")) library(p, character.only = TRUE); cat("ALL OK\n")'
+# Rust binary starts and answers?
+docker run --rm -d --name ls-test league-simulator:review-test /usr/local/bin/league-simulator-rust --api
+sleep 3 && docker exec ls-test curl -sf http://localhost:8080/health && docker rm -f ls-test
+# Size comparison (informational):
+docker images league-simulator:review-test
+```
+
+Expected: `1001`, `ALL OK`, health JSON. If any R package fails to load with a missing-`.so` error, add the corresponding runtime lib to stage 3.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Dockerfile league-simulator-rust/Cargo.lock
+git commit -m "perf(docker): cache Rust dependency layer, add slim non-root runtime stage"
+```
+
+---
+
+### Task 8: Vectorize transform_data
+
+**Files:**
+- Modify: `RCode/transform_data.R:34-39,55-67`
+- Test: `tests/testthat/test-transform_data.R` (existing — characterization safety net)
+
+- [ ] **Step 1: Baseline** — `Rscript -e 'testthat::test_file("tests/testthat/test-transform_data.R")'` → all green. If any test fails BEFORE the change, stop and report.
+
+- [ ] **Step 2: Replace the goals-to-NA loop (lines 34-39)**
+
+```r
+  # set goals to NA unless game is finished
+  # (FT = full time, AET = after extra time, PEN = decided on penalties)
+  unfinished <- !df_final$fixture_status_short %in% c("FT", "AET", "PEN")
+  df_final$ToreHeim[unfinished] <- NA
+  df_final$ToreGast[unfinished] <- NA
+```
+
+- [ ] **Step 3: Replace the nested ELO-propagation loop (lines 55-67)**
+
+The old loop finds a team's (constant) ELO among its rows — capped at row 50, silently wrong for teams first appearing later, and inheriting the previous column's ELO if none found. New version scans ALL rows and yields NA for a team with no appearance (more correct):
+
+```r
+  # Each team column carries the team's InitialELO in every row where the
+  # team plays. Keep it only in the first line; all other lines become NA.
+  for (i in 5:ncol(df_final)) {
+    col_values <- df_final[[i]]
+    first_elo <- col_values[which(!is.na(col_values))[1]]
+    df_final[[i]] <- c(first_elo, rep(NA_real_, nrow(df_final) - 1))
+  }
+```
+
+Also delete the now-unused `temp_ELO <- 0` at the top of the function.
+
+- [ ] **Step 4: Run tests + lint**
+
+Run: `Rscript -e 'testthat::test_file("tests/testthat/test-transform_data.R")'`
+Expected: PASS (same results as baseline).
+Run: `Rscript -e 'lintr::lint("RCode/transform_data.R")'` → no new findings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add RCode/transform_data.R
+git commit -m "perf: vectorize transform_data, remove hardcoded 50-row ELO scan cap"
+```
+
+---
+
+### Task 9: Vectorize Tabelle_presentation W/D/L counting
+
+**Files:**
+- Modify: `RCode/Tabelle_presentation.R:77-116`
+- Test: `tests/testthat/test-Tabelle.R` (existing)
+
+- [ ] **Step 1: Baseline** — `Rscript -e 'testthat::test_file("tests/testthat/test-Tabelle.R")'` → all green.
+
+- [ ] **Step 2: Replace the per-game loop** (keep the `wins/draws/losses/games_played` initializations above):
+
+```r
+  if (numberGames > 0 && nrow(season) > 0) {
+    played <- !is.na(season[, 3]) & !is.na(season[, 4])
+    s <- season[played, , drop = FALSE]
+    if (nrow(s) > 0) {
+      games_played <- tabulate(s[, 1], nbins = numberTeams) +
+        tabulate(s[, 2], nbins = numberTeams)
+      home_win <- s[, 3] > s[, 4]
+      away_win <- s[, 3] < s[, 4]
+      draw <- s[, 3] == s[, 4]
+      wins <- tabulate(s[home_win, 1], nbins = numberTeams) +
+        tabulate(s[away_win, 2], nbins = numberTeams)
+      losses <- tabulate(s[away_win, 1], nbins = numberTeams) +
+        tabulate(s[home_win, 2], nbins = numberTeams)
+      draws <- tabulate(s[draw, 1], nbins = numberTeams) +
+        tabulate(s[draw, 2], nbins = numberTeams)
+    }
+  }
+```
+
+- [ ] **Step 3: Run tests + lint**
+
+Run: `Rscript -e 'testthat::test_file("tests/testthat/test-Tabelle.R")'` → PASS.
+Run: `Rscript -e 'lintr::lint("RCode/Tabelle_presentation.R")'` → no new findings.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add RCode/Tabelle_presentation.R
+git commit -m "perf: vectorize W/D/L counting in Tabelle_presentation"
+```
+
+---
+
+### Task 10: Rate-limit header reuse + remove debug payload logging
+
+**Files:**
+- Modify: `RCode/retrieveResults.R`
+- Modify: `RCode/checkAPILimits.R`
+- Modify: `RCode/rust_integration.R:90-92`
+
+**Interfaces:**
+- Produces: environment `.api_rate_limit` (defined in `retrieveResults.R`) with fields `remaining`, `limit`, `as_of`; populated by every successful `retrieveResults()`/`retrieveLiveFixtures()` call. `checkAPILimits()` consumes it when fresh (< 10 min) instead of spending an extra request. Task 11 consumes `.api_rate_limit` too.
+
+- [ ] **Step 1: In `retrieveResults.R`**, add at top level (above the function):
+
+```r
+# Last-seen API-Football rate-limit headers, shared across callers so
+# checkAPILimits() can avoid spending a request just to read them.
+.api_rate_limit <- new.env(parent = emptyenv())
+
+.record_rate_limit_headers <- function(response) {
+  hdrs <- httr::headers(response)
+  remaining <- suppressWarnings(as.numeric(hdrs[["x-ratelimit-requests-remaining"]]))
+  if (!is.na(remaining)) {
+    .api_rate_limit$remaining <- remaining
+    .api_rate_limit$limit <- suppressWarnings(as.numeric(hdrs[["x-ratelimit-requests-limit"]]))
+    .api_rate_limit$as_of <- Sys.time()
+  }
+  invisible(NULL)
+}
+```
+
+Inside `retrieveResults()`, directly after the `status_code(response) != 200` early return, add:
+
+```r
+  .record_rate_limit_headers(response)
+```
+
+- [ ] **Step 2: In `checkAPILimits.R`**, after the api_key check and before making the HTTP call, add:
+
+```r
+  # Reuse rate-limit headers captured by a recent retrieveResults() call
+  # instead of spending a request on a dedicated probe.
+  if (exists(".api_rate_limit") &&
+    !is.null(.api_rate_limit$remaining) &&
+    difftime(Sys.time(), .api_rate_limit$as_of, units = "mins") < 10) {
+    remaining <- .api_rate_limit$remaining
+    limit <- .api_rate_limit$limit
+    message(sprintf(
+      "API Rate Limit (cached): %d/%d requests remaining",
+      remaining, limit
+    ))
+    safe_loops <- floor((remaining * safety_margin) / avg_calls_per_loop)
+    return(min(ideal_loops, safe_loops))
+  }
+```
+
+Rename the parameter `num_leagues = 3` to `avg_calls_per_loop = 2` (Task 11 reduces steady-state cost to ~1 live call/loop plus occasional full fetches; 2 is the conservative planning average) and update the formula comment plus the `safe_loops` division accordingly. Callers in `updateScheduler.R` pass only `ideal_loops`, so no call-site change is needed.
+
+- [ ] **Step 3: In `rust_integration.R`**, delete lines 90-92:
+
+```r
+  # Debug JSON payload
+  json_body <- toJSON(payload, auto_unbox = TRUE, null = "null")
+  message("DEBUG: First schedule entry JSON: ", substr(json_body, 1, 200))
+```
+
+becomes:
+
+```r
+  json_body <- toJSON(payload, auto_unbox = TRUE, null = "null")
+```
+
+(The DEBUG block in the error path at lines 104-109 stays — it only runs on failure and is genuinely useful.)
+
+- [ ] **Step 4: Verify**
+
+Run: `Rscript -e 'testthat::test_file("tests/testthat/test-rust-required.R")'` → PASS.
+Run: `Rscript -e 'lintr::lint("RCode/retrieveResults.R")' && Rscript -e 'lintr::lint("RCode/checkAPILimits.R")' && Rscript -e 'lintr::lint("RCode/rust_integration.R")'` → no new findings.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add RCode/retrieveResults.R RCode/checkAPILimits.R RCode/rust_integration.R
+git commit -m "perf: reuse cached rate-limit headers, drop per-call debug payload log"
+```
+
+---
+
+### Task 11: Gate full fixture fetches behind a cheap live-fixtures poll
+
+**Files:**
+- Modify: `RCode/retrieveResults.R` (add `retrieveLiveFixtures`)
+- Modify: `RCode/update_all_leagues_loop.R`
+- Test: `tests/testthat/test-update-loop-gating.R` (create)
+
+**Interfaces:**
+- Consumes: `.record_rate_limit_headers` from Task 10.
+- Produces: `retrieveLiveFixtures(league_ids = c("78", "79", "80"))` → integer vector of live fixture IDs, `integer(0)` when none, `NULL` on API error (callers must treat NULL as "unknown → do the full fetch"). New `update_all_leagues_loop()` parameter `full_fetch_every = 30`.
+
+**Design:** A match can only newly reach FT if it was live at the previous poll. So: poll the live endpoint (1 request for all three leagues); do the full 3-request fetch only when (a) first iteration, (b) a previously-live fixture is no longer live (it likely finished), (c) the live poll errored, or (d) `full_fetch_every` loops have passed since the last full fetch (safety net for administratively awarded/postponed results). Steady-state cost drops from 3 requests/loop to ~1.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/testthat/test-update-loop-gating.R`:
+
+```r
+# The production loop must not do a full 3-league fixture fetch on every
+# iteration: it polls the cheap live endpoint and fetches fully only when
+# a live fixture disappeared (finished), on the first iteration, or on the
+# periodic safety net.
+
+test_that("full fetch happens only on loop 1 and when a live fixture ends", {
+  # Stub network + heavy dependencies before sourcing the loop
+  full_fetch_leagues <- character()
+  live_poll_count <- 0
+  live_sequence <- list(
+    c(101L, 102L), # loop 2: two matches live -> no full fetch
+    c(101L, 102L), # loop 3: unchanged        -> no full fetch
+    c(102L),       # loop 4: 101 finished     -> full fetch
+    integer(0)     # loop 5: 102 finished     -> full fetch
+  )
+
+  fake_fixtures <- readRDS(test_path("fixtures", "sample_fixtures.rds"))
+
+  local_mocked_bindings(
+    retrieveResults = function(league, season) {
+      full_fetch_leagues <<- c(full_fetch_leagues, league)
+      fake_fixtures
+    },
+    retrieveLiveFixtures = function(...) {
+      live_poll_count <<- live_poll_count + 1
+      live_sequence[[min(live_poll_count, length(live_sequence))]]
+    },
+    leagueSimulatorRust = function(...) matrix(1 / 18, nrow = 18, ncol = 18),
+    updateShiny = function(...) invisible(NULL),
+    connect_rust_simulator = function() TRUE,
+    transform_data = function(...) readRDS(test_path("fixtures", "sample_transformed.rds")),
+    .env = globalenv()
+  )
+
+  update_all_leagues_loop(
+    duration = 0, loops = 5, initial_wait = 0, n = 10,
+    saison = "2024", TeamList_file = test_path("fixtures", "sample_teamlist.csv"),
+    shiny_directory = tempdir(), full_fetch_every = 30
+  )
+
+  # Full fetches: loop 1 (always), loop 4 and loop 5 (fixture left live set)
+  # -> 3 full fetches x 3 leagues = 9 retrieveResults calls
+  expect_length(full_fetch_leagues, 9)
+  expect_equal(live_poll_count, 4) # loops 2-5
+})
+```
+
+**Implementer notes for this test:** inspect `tests/testthat/fixtures/` and `helper-fixtures.R` first — reuse whatever canned fixture objects already exist for `transform_data`/loop tests instead of the `sample_*.rds` names above; adapt names/paths to what is actually there. If no suitable canned fixtures exist, build a minimal in-memory substitute: `transform_data` is mocked anyway, so `retrieveResults` can return any list with `fixture$status$short` (e.g. `list(fixture = list(status = list(short = c("FT", "NS"))))`) and the mocked `transform_data` can return a small tibble with 4+18 columns matching what `leagueSimulatorRust` (also mocked) receives. The point under test is ONLY the call-counting logic. If `local_mocked_bindings` on `globalenv()` proves unreliable for `source()`d functions, source `update_all_leagues_loop.R` into a dedicated environment and mock there.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `Rscript -e 'testthat::test_file("tests/testthat/test-update-loop-gating.R")'`
+Expected: FAIL — `retrieveLiveFixtures` doesn't exist / `full_fetch_every` unknown argument / 15 full fetches instead of 9.
+
+- [ ] **Step 3: Add `retrieveLiveFixtures` to `RCode/retrieveResults.R`**
+
+```r
+retrieveLiveFixtures <- function(league_ids = c("78", "79", "80")) {
+  require(httr)
+  require(jsonlite)
+
+  RAPIDAPI_KEY <- Sys.getenv("RAPIDAPI_KEY")
+
+  # One request covering all leagues: fixtures currently in play
+  response <- VERB("GET", "https://api-football-v1.p.rapidapi.com/v3/fixtures",
+    query = list(live = paste(league_ids, collapse = "-")),
+    add_headers(
+      "X-RapidAPI-Key" = RAPIDAPI_KEY,
+      "X-RapidAPI-Host" = "api-football-v1.p.rapidapi.com"
+    ),
+    content_type("application/octet-stream")
+  )
+
+  if (status_code(response) != 200) {
+    warning(paste("Live fixtures request failed with status:", status_code(response)))
+    return(NULL) # NULL = unknown; caller must fall back to a full fetch
+  }
+
+  .record_rate_limit_headers(response)
+
+  parsed <- fromJSON(content(response, "text", encoding = "UTF-8"))
+  if (is.null(parsed$response) || length(parsed$response) == 0) {
+    return(integer(0)) # nothing live right now
+  }
+  as.integer(parsed$response$fixture$id)
+}
+```
+
+- [ ] **Step 4: Rework `RCode/update_all_leagues_loop.R`**
+
+Signature gains `full_fetch_every = 30`. After the `FT_*` initializations add:
+
+```r
+  # Live-poll gating state: a fixture can only newly reach FT if it was live
+  # at the previous poll, so a cheap 1-request live check replaces the full
+  # 3-request fetch on most iterations. full_fetch_every is the safety net
+  # for status changes that bypass "live" (awarded/postponed results).
+  prev_live_ids <- NULL # NULL = unknown (no live poll yet)
+  last_full_fetch_loop <- 0
+```
+
+Inside the `for (i in 1:loops)` loop, insert the gate between the `simulation_executed <- FALSE` line and the fixture fetching, and wrap the existing fetch/transform/simulate/deploy body in `if (need_full_fetch) { ... }`:
+
+```r
+    # Decide whether the full 3-league fetch is needed this iteration
+    need_full_fetch <- TRUE
+    if (i > 1) {
+      live_ids <- retrieveLiveFixtures()
+      if (is.null(live_ids)) {
+        message(sprintf("Loop %d: live poll failed, falling back to full fetch", i))
+      } else {
+        finished_since_last <- !is.null(prev_live_ids) &&
+          length(setdiff(prev_live_ids, live_ids)) > 0
+        due_safety_fetch <- (i - last_full_fetch_loop) >= full_fetch_every
+        if (!finished_since_last && !due_safety_fetch) {
+          need_full_fetch <- FALSE
+        }
+        prev_live_ids <- live_ids
+      }
+    }
+
+    if (need_full_fetch) {
+      last_full_fetch_loop <- i
+
+      # ... ENTIRE existing body: retrieveResults x3, NULL check,
+      #     FT counts, transform_data x3, Liga3 penalty loop,
+      #     the three simulation blocks, and the updateShiny block ...
+    } else {
+      message(sprintf(
+        "Loop %d: %d fixture(s) live, none finished since last poll - skipping full fetch",
+        i, length(prev_live_ids)
+      ))
+    }
+
+    # Wait if not last iteration  (existing code, stays OUTSIDE the gate)
+```
+
+Take care: the existing `next` on API failure (line 77) stays inside the gated block and still works (it skips the wait — pre-existing behavior, leave as is).
+
+- [ ] **Step 5: Run tests**
+
+Run: `Rscript -e 'testthat::test_file("tests/testthat/test-update-loop-gating.R")'` → PASS.
+Run: `Rscript -e 'testthat::test_file("tests/testthat/test-rust-required.R")'` → still PASS.
+Run: `Rscript -e 'lintr::lint("RCode/update_all_leagues_loop.R")' ; Rscript -e 'lintr::lint("RCode/retrieveResults.R")'` → no new findings.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add RCode/retrieveResults.R RCode/update_all_leagues_loop.R tests/testthat/test-update-loop-gating.R
+git commit -m "perf: gate full fixture fetches behind 1-request live poll (API budget)"
+```
+
+---
+
+### Task 12: Shiny app — graceful missing-data handling, stale-data banner, Liga3 consistency
+
+**Files:**
+- Create: `ShinyApp/app_helpers.R`
+- Modify: `ShinyApp/app.R`
+- Modify: `RCode/updateShiny.R` (deploy `app_helpers.R`)
+- Test: `tests/testthat/test-shiny-app-helpers.R` (create)
+
+**Interfaces:**
+- Produces: `app_helpers.R` with `load_results(path)` → TRUE/FALSE (loads into caller-supplied env), `data_age_hours(mtime, now)` → numeric, `stale_warning_text(age_hours, threshold_hours)` → string or NULL.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/testthat/test-shiny-app-helpers.R`:
+
+```r
+helpers_path <- test_path("..", "..", "ShinyApp", "app_helpers.R")
+
+test_that("load_results returns FALSE for missing or corrupt file", {
+  source(helpers_path, local = TRUE)
+  expect_false(load_results(file.path(tempdir(), "does_not_exist.Rds"), new.env()))
+  corrupt <- tempfile(fileext = ".Rds")
+  writeLines("not an rds", corrupt)
+  expect_false(load_results(corrupt, new.env()))
+})
+
+test_that("load_results loads a valid results file", {
+  source(helpers_path, local = TRUE)
+  Ergebnis <- matrix(1 / 18, 18, 18)
+  f <- tempfile(fileext = ".Rds")
+  save(Ergebnis, file = f)
+  env <- new.env()
+  expect_true(load_results(f, env))
+  expect_true(exists("Ergebnis", envir = env))
+})
+
+test_that("data_age_hours computes hours between mtime and now", {
+  source(helpers_path, local = TRUE)
+  now <- as.POSIXct("2026-07-02 18:00:00", tz = "Europe/Berlin")
+  mtime <- as.POSIXct("2026-07-01 18:00:00", tz = "Europe/Berlin")
+  expect_equal(data_age_hours(mtime, now), 24)
+})
+
+test_that("stale_warning_text triggers only past the threshold", {
+  source(helpers_path, local = TRUE)
+  expect_null(stale_warning_text(3, threshold_hours = 24))
+  msg <- stale_warning_text(49.6, threshold_hours = 24)
+  expect_match(msg, "50 Stunden")
+})
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `Rscript -e 'testthat::test_file("tests/testthat/test-shiny-app-helpers.R")'`
+Expected: FAIL — `app_helpers.R` does not exist.
+
+- [ ] **Step 3: Create `ShinyApp/app_helpers.R`**
+
+```r
+# Helper functions for the Shiny app. Kept in a separate file so they are
+# unit-testable; deployed alongside app.R (see updateShiny.R appFiles).
+
+load_results <- function(path, envir) {
+  tryCatch(
+    {
+      load(path, envir = envir)
+      TRUE
+    },
+    error = function(e) FALSE,
+    warning = function(w) FALSE
+  )
+}
+
+data_age_hours <- function(mtime, now = Sys.time()) {
+  as.numeric(difftime(now, mtime, units = "hours"))
+}
+
+stale_warning_text <- function(age_hours, threshold_hours = 24) {
+  if (is.na(age_hours) || age_hours <= threshold_hours) {
+    return(NULL)
+  }
+  sprintf(
+    "Achtung: Diese Prognosen sind %.0f Stunden alt und werden derzeit nicht aktualisiert.",
+    age_hours
+  )
+}
+```
+
+- [ ] **Step 4: Rework `ShinyApp/app.R`**
+
+Replace lines 17-18 (`load(...)` / `updatetime <- ...`) with:
+
+```r
+source("app_helpers.R", local = TRUE)
+
+data_loaded <- load_results("data/Ergebnis.Rds", environment())
+updatetime <- if (data_loaded) {
+  as.POSIXlt(file.mtime("data/Ergebnis.Rds"), tz = "Europe/Berlin")
+} else {
+  NULL
+}
+stale_message <- if (data_loaded) {
+  stale_warning_text(data_age_hours(updatetime))
+} else {
+  NULL
+}
+```
+
+Replace the `ui <- shinyUI(...)` block with a conditional UI (existing widgets unchanged, plus the banner):
+
+```r
+ui <- shinyUI(fluidPage(
+
+   # Application title
+   titlePanel("Fußball-Prognosen von 30Punkte"),
+
+   if (!data_loaded) {
+     mainPanel(
+       h3("Noch keine Prognosedaten verfügbar"),
+       p("Die Simulationsergebnisse wurden noch nicht erzeugt oder konnten",
+         "nicht geladen werden. Bitte versuchen Sie es später erneut."),
+       helpText("Nähere Infos unter ",
+                a("30punkte.wordpress.com",
+                  href = "http://30punkte.wordpress.com", target = "blank_"))
+     )
+   } else {
+     verticalLayout(
+       mainPanel(
+         if (!is.null(stale_message)) {
+           div(
+             style = paste(
+               "background-color:#f8d7da; color:#721c24;",
+               "padding:10px; border-radius:4px; margin-bottom:12px;"
+             ),
+             stale_message
+           )
+         },
+         selectInput(inputId = "Liga",
+                     choices = c("Bundesliga", "2. Bundesliga", "Dritte Liga"),
+                     label = "Welche Liga soll dargestellt werden?",
+                     selected = "Bundesliga"),
+         plotOutput(outputId = "Plot"),
+         tableOutput(outputId = "Oben"),
+         tableOutput(outputId = "Unten"),
+         helpText("Alle Prognosen als Wahrscheinlichkeiten in Prozent angegeben. Nähere Infos unter ",
+                  a("30punkte.wordpress.com", href = "http://30punkte.wordpress.com", target = "blank_"),
+                  paste("Letztes Update: ",
+                        format(updatetime, "%d.%m.%Y %H:%M"),
+                        " ",
+                        # isdst: >0 = DST (MESZ), 0 = standard (MEZ), <0 = unknown -> falls through to MEZ
+                        if (updatetime$isdst > 0) "MESZ" else "MEZ",
+                        sep = "")
+         )
+       )
+     )
+   }
+))
+```
+
+In the server function, guard every render with `req(data_loaded)` as first line, e.g.:
+
+```r
+    output$Oben <- renderTable({
+    req(data_loaded)
+    if (input$Liga == "Bundesliga") {
+```
+
+(same for `output$Unten` and `output$Plot`).
+
+Unify the Liga3 relegation table (line 177) with the `groupResultsDF` pattern used everywhere else:
+
+```r
+      apply (groupResultsDF (Ergebnis3[rowSums(Ergebnis3[,17:20])>=0.01,],
+                             labels = c("Abstieg"),
+                             groups = cbind (c(17,20))),
+             c (1,2), prozent)
+```
+
+- [ ] **Step 5: Deploy the helper file — `RCode/updateShiny.R`**
+
+```r
+  deployApp(
+    appFiles = c("app.R", "app_helpers.R", "data/Ergebnis.Rds"),
+    appName = "FussballPrognosen", forceUpdate = forceUpdate
+  )
+```
+
+- [ ] **Step 6: Run tests**
+
+Run: `Rscript -e 'testthat::test_file("tests/testthat/test-shiny-app-helpers.R")'` → PASS.
+Run: `Rscript -e 'testthat::test_file("tests/testthat/test-shiny-footer-timezone.R")'` → PASS (this test parses app.R; if it fails, adapt it to the new structure — the footer logic itself is unchanged).
+Smoke-run the app headless:
+`Rscript -e 'setwd("ShinyApp"); app <- shiny::shinyAppFile("app.R"); cat("APP PARSES OK\n")'` → `APP PARSES OK` (works even without data/Ergebnis.Rds — that is the point).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add ShinyApp/app_helpers.R ShinyApp/app.R RCode/updateShiny.R tests/testthat/test-shiny-app-helpers.R
+git commit -m "fix(ux): graceful Shiny fallback without data, stale-data banner, consistent Liga3 table"
+```
+
+---
+
+### Task 13: Remove dead health_endpoints.R
+
+**Files:**
+- Delete: `ShinyApp/health_endpoints.R`
+- Delete: its test (locate via `grep -rln "health_endpoints\|perform_health_check" tests/`) — expected: `tests/deployment/pre-deployment/test_health_checks.R`
+- Modify: `docs/deployment/README.md` (only if it references the R health file — check with `grep -n "health_endpoints" docs/deployment/README.md`)
+
+Rationale: verified dead code — never sourced by app.R, scheduler, or Docker entrypoint; the real health endpoint is the Rust server's `/health`. Its only useful idea (stale-data detection) is now live in the app via Task 12.
+
+- [ ] **Step 1: Verify deadness once more**
+
+Run: `grep -rn "health_endpoints" --include="*.R" --include="*.sh" --include="Dockerfile*" . | grep -v tests/ | grep -v "^Binary"`
+Expected: only `ShinyApp/health_endpoints.R` itself. If ANY production reference appears, STOP and report instead of deleting.
+
+- [ ] **Step 2: Delete**
+
+```bash
+git rm ShinyApp/health_endpoints.R
+git rm tests/deployment/pre-deployment/test_health_checks.R   # adjust path per grep
+```
+
+If `docs/deployment/README.md` mentions the file, remove/replace that mention (the Rust `/health` docs stay).
+
+- [ ] **Step 3: Verify nothing breaks**
+
+Run: `Rscript -e 'testthat::test_file("tests/testthat/test-shiny-app-helpers.R")'` → PASS.
+Run: `grep -rn "health_endpoints" . --exclude-dir=.git || echo CLEAN` → `CLEAN` (this plan file excepted).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "chore: remove dead ShinyApp health_endpoints.R (superseded by Rust /health + in-app stale banner)"
+```
+
+---
+
+### Task 14: Fix season-transition docs and argument-error echo
+
+**Files:**
+- Modify: `docs/user-guide/season-transition.md`
+- Modify: `scripts/season_transition.R` (arg-error message + usage output)
+
+- [ ] **Step 1: Doc fixes in `docs/user-guide/season-transition.md`** (verified against the actual code):
+
+1. **Container name** — replace every `docker-compose exec` target `league-simulator` with `league-simulator-integrated` (lines 38, 55, 87, 97, 136→deleted below, 147, 161, 241→deleted below, 368, 373, 382). Global check afterwards: `grep -n "exec.*league-simulator \\\\" docs/user-guide/season-transition.md` → no hits.
+2. **Line 104** — `./scripts/backup_season.sh 2024` does not exist. Replace with:
+   ```bash
+   # Backup current data
+   tar -czf "backup_season_2024_$(date +%Y%m%d).tar.gz" RCode/TeamList_2024.csv
+   ```
+3. **Lines 134-141** (`search_team(...)` block) — the function does not exist. Replace the whole code block with:
+   ```markdown
+   Team IDs can be looked up in the API-Football dashboard
+   (<https://dashboard.api-football.com>) or via the `/teams?search=<name>`
+   endpoint documented at <https://www.api-football.com/documentation-v3>.
+   ```
+4. **Lines 239-246** (`get_final_standings` block) — the file does not exist. Replace the code block with:
+   ```markdown
+   Verify the final standings against an official source (e.g. kicker.de or
+   the API-Football dashboard) before re-running the transition with a
+   corrected configuration file.
+   ```
+5. **Automation Script section (lines 347-401)** — fix the two `league-simulator` exec targets to `league-simulator-integrated`, and DELETE step 4 ("Test simulation", lines 380-394) entirely — it sources `RCode/leagueSimulatorCPP.R`, which was removed with the Rust migration. Renumber step 5 → 4.
+6. **Debug section (lines 405-415)** — check `grep -rn "SEASON_TRANSITION_DEBUG" scripts/ RCode/`. If the variable is not referenced anywhere, delete the "Debug Mode" subsection.
+7. **Related Documentation links (lines 465-470)** — verify each target exists (`ls docs/user-guide/team-management.md docs/operations/backup-recovery.md docs/troubleshooting/common-issues.md`). Remove list entries whose files don't exist.
+
+- [ ] **Step 2: Argument echo in `scripts/season_transition.R`**
+
+Replace (in `parse_arguments`):
+
+```r
+  if (length(season_args) != 2) {
+    return(list(valid = FALSE, error = "Two season arguments required"))
+  }
+```
+
+with:
+
+```r
+  if (length(season_args) != 2) {
+    received <- if (length(season_args) == 0) {
+      "none"
+    } else {
+      paste(shQuote(season_args), collapse = ", ")
+    }
+    return(list(valid = FALSE, error = sprintf(
+      "Two season arguments required, got %d (%s)",
+      length(season_args), received
+    )))
+  }
+```
+
+And in `main()`, print the specific error before the usage block:
+
+```r
+  if (!parsed_args$valid) {
+    cat("Error:", parsed_args$error, "\n\n")
+    cat("Usage: Rscript season_transition.R <source_season> <target_season> [options]\n")
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `Rscript scripts/season_transition.R 2024 2025 2026 --non-interactive 2>&1 | head -5`
+Expected: first line contains `got 3 ('2024', '2025', '2026')`.
+Run: `Rscript -e 'testthat::test_file("tests/testthat/test-season-transition-validators.R")'` → PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/user-guide/season-transition.md scripts/season_transition.R
+git commit -m "docs: align season-transition guide with actual code; echo bad CLI args"
+```
+
+---
+
+### Task 15: Final verification and PR
+
+- [ ] **Step 1: Full local test sweep**
+
+```bash
+cd league-simulator-rust && cargo test && cargo fmt --check && cargo clippy -- -D warnings && cd ..
+Rscript -e 'options(testthat.progress.max_fails = Inf); testthat::test_dir("tests/testthat", stop_on_failure = TRUE, reporter = "summary")'
+```
+
+Expected: Rust all green; R suite green (some tests may skip without RAPIDAPI_KEY — same as CI). If R packages are missing locally, fall back to per-file runs of every test file touched in this plan and note that CI runs the full suite in-image.
+
+- [ ] **Step 2: Push and open PR**
+
+```bash
+git push -u origin fix/codebase-review-2026-07
+gh pr create --title "Implement codebase review findings (security, efficiency, usability)" --body "$(cat <<'EOF'
+## Summary
+Implements all actionable findings from the 2026-07-02 codebase review.
+
+**Security**
+- Remove hardcoded ShinyApps.io token (env-only + hard fail); drop compose fallback default — token must be rotated, see deployment note below
+- Validate Rust simulation requests (team indices, iterations cap 100k, adjustment lengths) — fixes one-request remote DoS via integer underflow + panic=abort
+- Bind Rust API host port to 127.0.0.1; drop permissive CORS; 2 MB body limit
+- Non-root container user; stop logging RAPIDAPI_KEY prefix; pin GitHub Actions to SHAs
+
+**Efficiency**
+- Gate full fixture fetches behind a 1-request live poll (~3x fewer API calls)
+- Direct Poisson quantile for small lambda (hot path); lock-free rayon fold/reduce aggregation; per-thread buffer reuse
+- Dockerfile: cached Rust dependency layer + slim runtime stage without build toolchain
+- Vectorized transform_data and Tabelle_presentation; cached rate-limit headers
+
+**Usability**
+- Shiny app: friendly fallback when no data, stale-data banner (>24h), consistent Liga3 table
+- season-transition guide aligned with actual code (container name, removed references to non-existent scripts)
+- Removed dead ShinyApp/health_endpoints.R; season_transition.R echoes bad CLI args
+
+## Deployment note (breaking)
+`SHINYAPPS_IO_TOKEN` must now be set in `.env` — the compose fallback default is gone. Rotate the exposed token at shinyapps.io before deploying.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Watch CI** (`gh pr checks --watch`) and fix anything red.

--- a/docs/superpowers/plans/2026-07-26-connect-cloud-migration.md
+++ b/docs/superpowers/plans/2026-07-26-connect-cloud-migration.md
@@ -1,5 +1,10 @@
 # Connect Cloud Migration Implementation Plan
 
+> **SUPERSEDED — do not execute.** Replaced by
+> [`2026-07-26-static-site-generation.md`](2026-07-26-static-site-generation.md).
+> The project is leaving hosted Shiny entirely rather than migrating it, so the
+> OAuth service-account work here is unnecessary. Kept for reference.
+
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
 **Goal:** Make the unattended Shiny deployment path work against Posit Connect Cloud before the 2027-03-31 forced migration, without breaking the shinyapps.io path that serves production today.

--- a/docs/superpowers/plans/2026-07-26-connect-cloud-migration.md
+++ b/docs/superpowers/plans/2026-07-26-connect-cloud-migration.md
@@ -1,0 +1,869 @@
+# Connect Cloud Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the unattended Shiny deployment path work against Posit Connect Cloud before the 2027-03-31 forced migration, without breaking the shinyapps.io path that serves production today.
+
+**Architecture:** Introduce a deployment-backend seam in `RCode/updateShiny.R` selected by `SHINY_DEPLOY_TARGET`. Two authenticator functions (`authenticate_shinyapps`, `authenticate_connectcloud`) sit behind a `switch()`; everything after authentication — save results, `deployApp()` — stays identical. Both backends remain live so cutover and rollback are environment-variable flips.
+
+**Tech Stack:** R 4.6, `rsconnect` (>= 1.10.0), `testthat` 3.2.3, `withr` 3.0.2, Docker.
+
+## Global Constraints
+
+- **rsconnect >= 1.10.0** is required — `connectCloudClientCredentials()` was introduced there. Locally installed is 1.5.0; CRAN latest is 1.10.1.
+- **Default backend stays `shinyapps`** through every task. No task may change production behaviour when `SHINY_DEPLOY_TARGET` is unset.
+- Existing shinyapps.io credential hard-fail behaviour must keep working (regression-protected by `tests/testthat/test-updateShiny-env.R`).
+- Connect Cloud env vars: `CONNECT_CLOUD_CLIENT_ID`, `CONNECT_CLOUD_CLIENT_SECRET`, `CONNECT_CLOUD_ACCOUNT` (default `chrisschwer`).
+- Run the full suite with `Rscript -e 'source("tests/testthat.R")'`; single file with `Rscript -e 'testthat::test_file("tests/testthat/<file>.R")'`.
+- All credential checks must fire **before** any network call, so tests need no rsconnect mocking (pass `directory = tempdir()`).
+- Account is on the **Starter plan** → maps to Connect Cloud **Basic**, price frozen until 2029. Deadline **2027-03-31**.
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `RCode/updateShiny.R` | Backend seam, both authenticators, save + deploy | Modify (61 lines today) |
+| `RCode/updateScheduler.R` | Startup preflight for the selected backend | Modify lines 6, 16-18 |
+| `tests/testthat/test-updateShiny-env.R` | Credential + backend-selection tests | Extend |
+| `packagelist.txt` | Pin `rsconnect (>= 1.10.0)` | Modify line 14 |
+| `.env.example` | Document Connect Cloud vars | Modify |
+| `docs/deployment/README.md` | Env-var reference table | Modify |
+| `docs/deployment/connect-cloud-migration.md` | Operator runbook for cutover | Create |
+
+---
+
+### Task 1: Deployment backend seam with both authenticators
+
+Replaces the single hardcoded `setAccountInfo()` call with a selectable backend. Also fixes the two correctness defects in this file (unsafe CWD restore, non-existent default path) because they are in the lines being touched and are exactly the failure class a migration provokes.
+
+**Files:**
+- Modify: `RCode/updateShiny.R:1-60` (whole file)
+- Test: `tests/testthat/test-updateShiny-env.R`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces:
+  - `resolve_deploy_backend()` → character, one of `"shinyapps"` / `"connectcloud"`; stops on any other value.
+  - `authenticate_shinyapps()` → invisible NULL; stops if `SHINYAPPS_IO_TOKEN` or `SHINYAPPS_IO_SECRET` is empty.
+  - `authenticate_connectcloud()` → invisible NULL; stops if `CONNECT_CLOUD_CLIENT_ID` or `CONNECT_CLOUD_CLIENT_SECRET` is empty.
+  - `updateShiny(Ergebnis, Ergebnis2, Ergebnis3, Ergebnis3_Aufstieg, directory, forceUpdate)` — signature unchanged except the `directory` default.
+
+- [ ] **Step 1: Write the failing tests for backend selection and Connect Cloud credentials**
+
+Append to `tests/testthat/test-updateShiny-env.R`:
+
+```r
+# --- Backend selection -------------------------------------------------------
+
+test_that("updateShiny defaults to the shinyapps backend when SHINY_DEPLOY_TARGET is unset", {
+  updateShiny <- source_updateShiny()
+  withr::local_envvar(c(
+    SHINY_DEPLOY_TARGET = NA,
+    SHINYAPPS_IO_TOKEN = "", SHINYAPPS_IO_SECRET = "dummy"
+  ))
+  # Falling through to the shinyapps credential check proves shinyapps is the default.
+  expect_error(
+    updateShiny(NULL, NULL, NULL, directory = tempdir()),
+    "SHINYAPPS_IO_TOKEN"
+  )
+})
+
+test_that("updateShiny rejects an unknown SHINY_DEPLOY_TARGET with an actionable message", {
+  updateShiny <- source_updateShiny()
+  withr::local_envvar(c(SHINY_DEPLOY_TARGET = "heroku"))
+  expect_error(
+    updateShiny(NULL, NULL, NULL, directory = tempdir()),
+    "SHINY_DEPLOY_TARGET"
+  )
+})
+
+# --- Connect Cloud credentials ----------------------------------------------
+
+test_that("connectcloud backend stops when CONNECT_CLOUD_CLIENT_ID is not set", {
+  updateShiny <- source_updateShiny()
+  withr::local_envvar(c(
+    SHINY_DEPLOY_TARGET = "connectcloud",
+    CONNECT_CLOUD_CLIENT_ID = "", CONNECT_CLOUD_CLIENT_SECRET = "dummy"
+  ))
+  expect_error(
+    updateShiny(NULL, NULL, NULL, directory = tempdir()),
+    "CONNECT_CLOUD_CLIENT_ID"
+  )
+})
+
+test_that("connectcloud backend stops when CONNECT_CLOUD_CLIENT_SECRET is not set", {
+  updateShiny <- source_updateShiny()
+  withr::local_envvar(c(
+    SHINY_DEPLOY_TARGET = "connectcloud",
+    CONNECT_CLOUD_CLIENT_ID = "dummy", CONNECT_CLOUD_CLIENT_SECRET = ""
+  ))
+  expect_error(
+    updateShiny(NULL, NULL, NULL, directory = tempdir()),
+    "CONNECT_CLOUD_CLIENT_SECRET"
+  )
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `Rscript -e 'testthat::test_file("tests/testthat/test-updateShiny-env.R")'`
+
+Expected: the two pre-existing shinyapps tests PASS; the four new tests FAIL. The unknown-target test fails because no `SHINY_DEPLOY_TARGET` handling exists; the Connect Cloud tests fail because `updateShiny` still reads `SHINYAPPS_IO_*` unconditionally and errors with `"SHINYAPPS_IO_TOKEN"` instead of the expected message.
+
+- [ ] **Step 3: Rewrite `RCode/updateShiny.R` with the seam**
+
+Replace the entire file:
+
+```r
+# Shiny deployment.
+#
+# Two deployment backends are supported, selected by SHINY_DEPLOY_TARGET:
+#   shinyapps    (default) - legacy shinyapps.io, static token/secret
+#   connectcloud           - Posit Connect Cloud, OAuth2 client credentials
+#
+# shinyapps.io is being retired by Posit; paid accounts are force-migrated on
+# 2027-03-31. See docs/deployment/connect-cloud-migration.md for the cutover.
+
+resolve_deploy_backend <- function() {
+  target <- tolower(trimws(Sys.getenv("SHINY_DEPLOY_TARGET", "shinyapps")))
+  if (target == "") {
+    target <- "shinyapps"
+  }
+  if (!target %in% c("shinyapps", "connectcloud")) {
+    stop(sprintf(
+      paste0(
+        "ERROR: unsupported SHINY_DEPLOY_TARGET '%s'. ",
+        "Expected 'shinyapps' or 'connectcloud'."
+      ),
+      target
+    ))
+  }
+  target
+}
+
+authenticate_shinyapps <- function() {
+  account_name <- Sys.getenv("SHINYAPPS_IO_NAME", "chrisschwer")
+  account_token <- Sys.getenv("SHINYAPPS_IO_TOKEN")
+  account_secret <- Sys.getenv("SHINYAPPS_IO_SECRET")
+
+  if (account_token == "") {
+    stop("ERROR: SHINYAPPS_IO_TOKEN environment variable not set")
+  }
+  if (account_secret == "") {
+    stop("ERROR: SHINYAPPS_IO_SECRET environment variable not set")
+  }
+
+  message(sprintf("Authenticating to shinyapps.io as '%s'", account_name))
+  rsconnect::setAccountInfo(
+    name = account_name,
+    token = account_token,
+    secret = account_secret
+  )
+  invisible(NULL)
+}
+
+authenticate_connectcloud <- function() {
+  account_name <- Sys.getenv("CONNECT_CLOUD_ACCOUNT", "chrisschwer")
+  client_id <- Sys.getenv("CONNECT_CLOUD_CLIENT_ID")
+  client_secret <- Sys.getenv("CONNECT_CLOUD_CLIENT_SECRET")
+
+  if (client_id == "") {
+    stop("ERROR: CONNECT_CLOUD_CLIENT_ID environment variable not set")
+  }
+  if (client_secret == "") {
+    stop("ERROR: CONNECT_CLOUD_CLIENT_SECRET environment variable not set")
+  }
+
+  if (!exists("connectCloudClientCredentials", where = asNamespace("rsconnect"))) {
+    stop(paste(
+      "ERROR: installed rsconnect lacks connectCloudClientCredentials().",
+      "Connect Cloud deployment requires rsconnect >= 1.10.0; installed:",
+      as.character(utils::packageVersion("rsconnect"))
+    ))
+  }
+
+  message(sprintf("Authenticating to Posit Connect Cloud as '%s'", account_name))
+  rsconnect::connectCloudClientCredentials(
+    clientId = client_id,
+    clientSecret = client_secret,
+    accountName = account_name
+  )
+  invisible(NULL)
+}
+
+updateShiny <- function(Ergebnis, Ergebnis2, Ergebnis3,
+                        Ergebnis3_Aufstieg = Ergebnis3,
+                        directory = file.path(getwd(), "ShinyApp"),
+                        forceUpdate = TRUE) {
+  backend <- resolve_deploy_backend()
+
+  # Ensure all required packages are loaded
+  required_packages <- c("rsconnect", "shiny", "crayon", "ellipsis", "httpuv")
+
+  for (pkg in required_packages) {
+    if (!require(pkg, character.only = TRUE, quietly = TRUE)) {
+      stop(paste(
+        "Required package not available:", pkg,
+        "\nPlease ensure all dependencies are installed in the Docker container"
+      ))
+    }
+  }
+
+  # Use packrat mode to avoid "reproducible location" errors
+  options(rsconnect.packrat = TRUE)
+
+  switch(backend,
+    shinyapps = authenticate_shinyapps(),
+    connectcloud = authenticate_connectcloud()
+  )
+
+  # Restore the working directory even if the deploy fails: leaving the process
+  # inside ShinyApp/ breaks the next scheduler loop's relative source() paths.
+  curr_wd <- getwd()
+  on.exit(setwd(curr_wd), add = TRUE)
+
+  message(sprintf("Changing to directory: %s", directory))
+  setwd(directory)
+
+  if (!dir.exists("data")) {
+    message("Creating data directory")
+    dir.create("data", showWarnings = FALSE)
+  }
+
+  message("Saving simulation results to data/Ergebnis.Rds")
+  save(Ergebnis, Ergebnis2, Ergebnis3, Ergebnis3_Aufstieg, file = "data/Ergebnis.Rds")
+
+  message(sprintf("Deploying app via backend '%s'", backend))
+  rsconnect::deployApp(
+    appFiles = c("app.R", "app_helpers.R", "data/Ergebnis.Rds"),
+    appName = "FussballPrognosen", forceUpdate = forceUpdate
+  )
+
+  message("Deployment completed")
+  invisible(NULL)
+}
+```
+
+Three things changed beyond the seam: the `directory` default is now repo-relative (was an absolute `Dropbox-CSDataScience` path that does not exist in this checkout), the CWD restore moved into `on.exit()`, and the bare `library(rsconnect)` + `deployApp()` became a namespaced `rsconnect::deployApp()`.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `Rscript -e 'testthat::test_file("tests/testthat/test-updateShiny-env.R")'`
+
+Expected: all six tests PASS (2 pre-existing shinyapps + 4 new).
+
+- [ ] **Step 5: Run the full suite to check for regressions**
+
+Run: `Rscript -e 'source("tests/testthat.R")'`
+
+Expected: no new failures. Pay attention to `test-update-loop-gating.R` (stubs `updateShiny`) and `test-rust-required.R` (passes `shiny_directory = tempdir()`) — both exercise this call path.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add RCode/updateShiny.R tests/testthat/test-updateShiny-env.R
+git commit -m "feat: add Connect Cloud deployment backend behind SHINY_DEPLOY_TARGET
+
+shinyapps.io is being retired; setAccountInfo() has no Connect Cloud
+equivalent and connectCloudUser() is a browser handshake unusable from a
+headless container. Add connectCloudClientCredentials() (OAuth2 service
+account) behind a backend seam, defaulting to shinyapps so production
+behaviour is unchanged.
+
+Also fixes two defects in the touched lines: restore the working
+directory via on.exit() so a failed deploy cannot break the next
+scheduler loop, and replace the non-existent hardcoded directory default
+with a repo-relative one."
+```
+
+---
+
+### Task 2: CWD-restore regression test
+
+Task 1 fixed the unsafe CWD restore but nothing yet proves it. This locks it in, because the bug is invisible until a deploy fails in production.
+
+**Files:**
+- Test: `tests/testthat/test-updateShiny-env.R`
+
+**Interfaces:**
+- Consumes: `updateShiny()` and `resolve_deploy_backend()` from Task 1.
+- Produces: nothing consumed downstream.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/testthat/test-updateShiny-env.R`:
+
+```r
+test_that("updateShiny restores the working directory when deployment fails", {
+  updateShiny <- source_updateShiny()
+
+  app_dir <- withr::local_tempdir()
+  # updateShiny writes into data/ then deploys; give it a directory to cd into.
+  before <- getwd()
+
+  withr::local_envvar(c(
+    SHINY_DEPLOY_TARGET = "shinyapps",
+    SHINYAPPS_IO_NAME = "acct",
+    SHINYAPPS_IO_TOKEN = "tok", SHINYAPPS_IO_SECRET = "sec"
+  ))
+
+  # Force a failure at the deploy step, after the setwd() has happened.
+  mockery::stub(updateShiny, "rsconnect::setAccountInfo", function(...) invisible(NULL))
+  mockery::stub(updateShiny, "rsconnect::deployApp", function(...) stop("deploy boom"))
+
+  expect_error(
+    updateShiny(1, 2, 3, directory = app_dir),
+    "deploy boom"
+  )
+  expect_equal(normalizePath(getwd()), normalizePath(before))
+})
+```
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+Run: `Rscript -e 'testthat::test_file("tests/testthat/test-updateShiny-env.R")'`
+
+Expected: PASS. This test is written *after* the fix, so it should pass immediately — that is intentional here. To confirm it actually guards the behaviour, temporarily change `on.exit(setwd(curr_wd), add = TRUE)` back to a trailing `setwd(curr_wd)` in `RCode/updateShiny.R`, re-run, and observe the FAIL on the `expect_equal(getwd(), ...)` assertion. Then restore the `on.exit()` version.
+
+- [ ] **Step 3: Verify the guard, then restore**
+
+Run the temporary-revert check described in Step 2 and confirm you saw the failure. Restore `RCode/updateShiny.R` to the Task 1 version:
+
+```bash
+git checkout RCode/updateShiny.R
+```
+
+- [ ] **Step 4: Re-run the file to confirm green after restore**
+
+Run: `Rscript -e 'testthat::test_file("tests/testthat/test-updateShiny-env.R")'`
+
+Expected: all seven tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/testthat/test-updateShiny-env.R
+git commit -m "test: assert updateShiny restores CWD when deployment fails"
+```
+
+---
+
+### Task 3: Pin rsconnect and fail fast on an old version
+
+`packagelist.txt:14` is a bare `rsconnect`, so the Docker build installs whatever CRAN serves that day — meaning the production rsconnect version is currently accidental. Connect Cloud needs >= 1.10.0.
+
+**Files:**
+- Modify: `packagelist.txt:14`
+- Test: `tests/testthat/test-updateShiny-env.R`
+
+**Interfaces:**
+- Consumes: `authenticate_connectcloud()` from Task 1 (its version guard).
+- Produces: nothing consumed downstream.
+
+- [ ] **Step 1: Write the failing test for the version guard**
+
+Append to `tests/testthat/test-updateShiny-env.R`:
+
+```r
+test_that("packagelist pins rsconnect to a Connect Cloud capable version", {
+  pkgs <- readLines(test_path("..", "..", "packagelist.txt"), warn = FALSE)
+  rsconnect_line <- grep("^rsconnect", pkgs, value = TRUE)
+  expect_length(rsconnect_line, 1)
+  expect_match(rsconnect_line, "rsconnect \\(>= 1\\.10\\.0\\)", fixed = FALSE)
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `Rscript -e 'testthat::test_file("tests/testthat/test-updateShiny-env.R")'`
+
+Expected: FAIL — `packagelist.txt` line 14 is the bare string `rsconnect`, so `expect_match` does not find the version constraint.
+
+- [ ] **Step 3: Pin the dependency**
+
+In `packagelist.txt`, change line 14 from:
+
+```
+rsconnect
+```
+
+to:
+
+```
+rsconnect (>= 1.10.0)
+```
+
+Then check how the Docker build consumes this file. `Dockerfile:57` installs a hardcoded `shiny_pkgs <- c('htmltools', 'httpuv', 'promises', 'shiny', 'rsconnect')` vector rather than reading `packagelist.txt`, and `install.packages()` ignores version constraints in a plain name. So the pin is documentation unless the build enforces it. Add an explicit assertion after the R package installs in `Dockerfile` (immediately following the block ending at line 83):
+
+```dockerfile
+# Connect Cloud deployment needs rsconnect >= 1.10.0 (connectCloudClientCredentials).
+RUN Rscript -e 'v <- utils::packageVersion("rsconnect"); \
+    if (v < "1.10.0") stop(sprintf("rsconnect %s too old; need >= 1.10.0", v)); \
+    cat("rsconnect", as.character(v), "OK\n")'
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `Rscript -e 'testthat::test_file("tests/testthat/test-updateShiny-env.R")'`
+
+Expected: all eight tests PASS.
+
+- [ ] **Step 5: Verify the Docker build enforces the floor**
+
+Run: `docker build -t league-simulator:cc-test .`
+
+Expected: build succeeds and the log contains `rsconnect <version> OK` with a version >= 1.10.0. If the build fails on the version assertion, CRAN's current rsconnect is older than expected — investigate before proceeding rather than lowering the floor, since `connectCloudClientCredentials()` genuinely does not exist below 1.10.0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packagelist.txt Dockerfile tests/testthat/test-updateShiny-env.R
+git commit -m "build: require rsconnect >= 1.10.0 for Connect Cloud deployment
+
+The dependency was unpinned, so the image got whichever version CRAN
+served on build day. connectCloudClientCredentials() needs 1.10.0+;
+assert it at build time rather than discovering it at deploy time."
+```
+
+---
+
+### Task 4: Validate the selected backend's credentials at scheduler startup
+
+Today `updateScheduler.R:6,16-18` preflights `SHINYAPPS_IO_SECRET` but **not** `SHINYAPPS_IO_TOKEN`, so a missing token is discovered hours later inside the matchday loop. Connect Cloud vars are not checked at all. This converts a silent mid-loop failure into a loud startup failure.
+
+**Files:**
+- Modify: `RCode/updateScheduler.R:6,16-18`
+- Test: `tests/testthat/test-scheduler-deploy-preflight.R` (create)
+
+**Interfaces:**
+- Consumes: `resolve_deploy_backend()` from Task 1.
+- Produces: `validate_deploy_credentials()` → invisible NULL; stops with the name of the first missing variable for the selected backend.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/testthat/test-scheduler-deploy-preflight.R`:
+
+```r
+# The scheduler must reject missing deployment credentials at startup rather
+# than failing hours later inside the matchday loop.
+
+source_validator <- function() {
+  source(test_path("..", "..", "RCode", "updateShiny.R"), local = TRUE)
+  environment()$validate_deploy_credentials
+}
+
+test_that("shinyapps backend requires both token and secret at startup", {
+  validate <- source_validator()
+
+  withr::local_envvar(c(
+    SHINY_DEPLOY_TARGET = "shinyapps",
+    SHINYAPPS_IO_TOKEN = "", SHINYAPPS_IO_SECRET = "sec"
+  ))
+  expect_error(validate(), "SHINYAPPS_IO_TOKEN")
+})
+
+test_that("shinyapps backend rejects a missing secret at startup", {
+  validate <- source_validator()
+
+  withr::local_envvar(c(
+    SHINY_DEPLOY_TARGET = "shinyapps",
+    SHINYAPPS_IO_TOKEN = "tok", SHINYAPPS_IO_SECRET = ""
+  ))
+  expect_error(validate(), "SHINYAPPS_IO_SECRET")
+})
+
+test_that("connectcloud backend requires client id and secret at startup", {
+  validate <- source_validator()
+
+  withr::local_envvar(c(
+    SHINY_DEPLOY_TARGET = "connectcloud",
+    CONNECT_CLOUD_CLIENT_ID = "", CONNECT_CLOUD_CLIENT_SECRET = "sec"
+  ))
+  expect_error(validate(), "CONNECT_CLOUD_CLIENT_ID")
+})
+
+test_that("validation passes when the selected backend is fully configured", {
+  validate <- source_validator()
+
+  withr::local_envvar(c(
+    SHINY_DEPLOY_TARGET = "connectcloud",
+    CONNECT_CLOUD_CLIENT_ID = "id", CONNECT_CLOUD_CLIENT_SECRET = "sec"
+  ))
+  expect_silent(validate())
+})
+
+test_that("validation ignores the other backend's credentials", {
+  validate <- source_validator()
+
+  # connectcloud selected and configured; shinyapps vars deliberately empty.
+  withr::local_envvar(c(
+    SHINY_DEPLOY_TARGET = "connectcloud",
+    CONNECT_CLOUD_CLIENT_ID = "id", CONNECT_CLOUD_CLIENT_SECRET = "sec",
+    SHINYAPPS_IO_TOKEN = "", SHINYAPPS_IO_SECRET = ""
+  ))
+  expect_silent(validate())
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `Rscript -e 'testthat::test_file("tests/testthat/test-scheduler-deploy-preflight.R")'`
+
+Expected: FAIL — `validate_deploy_credentials` does not exist, so `source_validator()` returns NULL and calling it errors with "attempt to apply non-function".
+
+- [ ] **Step 3: Add the validator to `RCode/updateShiny.R`**
+
+Insert after `authenticate_connectcloud()` (before `updateShiny()`):
+
+```r
+# Startup preflight: check the selected backend's credentials without
+# performing any network call, so a misconfiguration fails at container start
+# instead of hours later inside the matchday loop.
+validate_deploy_credentials <- function() {
+  backend <- resolve_deploy_backend()
+
+  required <- switch(backend,
+    shinyapps = c("SHINYAPPS_IO_TOKEN", "SHINYAPPS_IO_SECRET"),
+    connectcloud = c("CONNECT_CLOUD_CLIENT_ID", "CONNECT_CLOUD_CLIENT_SECRET")
+  )
+
+  for (var in required) {
+    if (Sys.getenv(var) == "") {
+      stop(sprintf(
+        "ERROR: %s environment variable not set (required for SHINY_DEPLOY_TARGET='%s')",
+        var, backend
+      ))
+    }
+  }
+  invisible(NULL)
+}
+```
+
+- [ ] **Step 4: Wire it into the scheduler**
+
+In `RCode/updateScheduler.R`, delete the `SHINYAPPS_IO_SECRET` assignment on line 6 and replace the validation block on lines 16-18:
+
+```r
+if (SHINYAPPS_IO_SECRET == "") {
+  stop("ERROR: SHINYAPPS_IO_SECRET environment variable not set")
+}
+```
+
+with:
+
+```r
+# Validate deployment credentials for whichever backend is selected.
+source("RCode/updateShiny.R")
+validate_deploy_credentials()
+```
+
+Check whether `updateScheduler.R` already sources `updateShiny.R` later (`update_all_leagues_loop.R:59` does its own `source`). A second `source()` is harmless — it only redefines functions — but if `updateScheduler.R` already sources it at the top, reuse that instead of adding a duplicate line.
+
+- [ ] **Step 5: Run the new tests and the full suite**
+
+Run: `Rscript -e 'testthat::test_file("tests/testthat/test-scheduler-deploy-preflight.R")'`
+Expected: all five tests PASS.
+
+Run: `Rscript -e 'source("tests/testthat.R")'`
+Expected: no new failures.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add RCode/updateShiny.R RCode/updateScheduler.R tests/testthat/test-scheduler-deploy-preflight.R
+git commit -m "fix: validate deployment credentials at scheduler startup
+
+The preflight checked SHINYAPPS_IO_SECRET but never the token, so a
+missing token surfaced hours later mid-loop. Validate whichever backend
+is selected, including Connect Cloud, before the scheduler starts."
+```
+
+---
+
+### Task 5: Document the cutover for the operator
+
+The deploy is operator-run, not CI-run, so the runbook is the deliverable that makes this migration executable. Also removes now-wrong shinyapps references.
+
+**Files:**
+- Create: `docs/deployment/connect-cloud-migration.md`
+- Modify: `.env.example`
+- Modify: `docs/deployment/README.md` (env-var table, lines 18-30)
+
+**Interfaces:**
+- Consumes: env var names from Tasks 1 and 4.
+- Produces: nothing consumed downstream.
+
+- [ ] **Step 1: Add the Connect Cloud vars to `.env.example`**
+
+Replace the required/optional blocks:
+
+```bash
+# --- Required ---
+RAPIDAPI_KEY=your_rapidapi_key_here
+
+# Deployment backend: shinyapps (default) or connectcloud
+# SHINY_DEPLOY_TARGET=shinyapps
+
+# Required when SHINY_DEPLOY_TARGET=shinyapps
+SHINYAPPS_IO_SECRET=your_shinyapps_secret_here
+SHINYAPPS_IO_TOKEN=your_shinyapps_token_here
+
+# Required when SHINY_DEPLOY_TARGET=connectcloud
+# Issue credentials at https://login.posit.cloud/identity/credentials
+# CONNECT_CLOUD_CLIENT_ID=your_connect_cloud_client_id
+# CONNECT_CLOUD_CLIENT_SECRET=your_connect_cloud_client_secret
+
+# --- Optional (defaults shown) ---
+# SHINYAPPS_IO_NAME=chrisschwer
+# CONNECT_CLOUD_ACCOUNT=chrisschwer
+# SEASON=2025
+# DURATION=480
+# RUST_API_URL=http://localhost:8080
+# TZ=Europe/Berlin
+```
+
+- [ ] **Step 2: Update the env-var table in `docs/deployment/README.md`**
+
+Replace the `SHINYAPPS_*` rows with:
+
+```markdown
+| `SHINY_DEPLOY_TARGET` | no | `shinyapps` | Deployment backend: `shinyapps` or `connectcloud` |
+| `SHINYAPPS_IO_SECRET` | if `shinyapps` | — | ShinyApps.io deployment auth |
+| `SHINYAPPS_IO_TOKEN` | if `shinyapps` | — | ShinyApps.io account token (rotate if ever exposed; no default) |
+| `SHINYAPPS_IO_NAME` | no | `chrisschwer` | ShinyApps.io account name |
+| `CONNECT_CLOUD_CLIENT_ID` | if `connectcloud` | — | Connect Cloud service-account OAuth client ID |
+| `CONNECT_CLOUD_CLIENT_SECRET` | if `connectcloud` | — | Connect Cloud service-account OAuth client secret |
+| `CONNECT_CLOUD_ACCOUNT` | no | `chrisschwer` | Connect Cloud account to publish to |
+```
+
+Also fix the sentence below the table — it says "fill in the three required values", which is now wrong. Change to: "fill in `RAPIDAPI_KEY` plus the credentials for your chosen `SHINY_DEPLOY_TARGET`."
+
+- [ ] **Step 3: Write the operator runbook**
+
+Create `docs/deployment/connect-cloud-migration.md`:
+
+```markdown
+# Migrating from shinyapps.io to Posit Connect Cloud
+
+Posit is retiring shinyapps.io. This account (`chrisschwer`, Starter plan) is
+**force-migrated on 2027-03-31**; the self-serve migration tool shipped in
+September 2026. Starter maps to Connect Cloud **Basic**, with current pricing
+held until 2029.
+
+The Shiny app itself needs no changes. Only the unattended deploy path does:
+`setAccountInfo()` has no Connect Cloud equivalent, and the advertised
+replacement `connectCloudUser()` is an interactive browser handshake. The
+headless path is `connectCloudClientCredentials()` — an OAuth2 service account,
+requiring **rsconnect >= 1.10.0**.
+
+## One-time setup
+
+1. Issue service-account credentials at <https://login.posit.cloud/identity/credentials>.
+   Grant publish permission on the target account.
+2. Put them in `.env`:
+
+   ```bash
+   CONNECT_CLOUD_CLIENT_ID=...
+   CONNECT_CLOUD_CLIENT_SECRET=...
+   ```
+
+3. Use the migration tool in Connect Cloud to import `FussballPrognosen`. Test
+   the imported app before finalizing. Finalizing sets up a redirect from the
+   shinyapps.io URL and archives the app there.
+
+## Cutover
+
+Deploy backends are switched with one variable, so cutover and rollback are
+symmetric.
+
+```bash
+# Dry run against Connect Cloud from a local R session
+SHINY_DEPLOY_TARGET=connectcloud Rscript -e '
+  source("RCode/updateShiny.R")
+  validate_deploy_credentials()
+  cat("credentials OK\n")
+'
+```
+
+Then flip the container:
+
+```bash
+# .env
+SHINY_DEPLOY_TARGET=connectcloud
+```
+
+```bash
+docker-compose up -d
+docker-compose logs -f league-simulator-integrated
+```
+
+Confirm in the logs: `Authenticating to Posit Connect Cloud as 'chrisschwer'`
+followed by a successful deploy.
+
+## Rollback
+
+Set `SHINY_DEPLOY_TARGET=shinyapps` (or remove the line — `shinyapps` is the
+default) and restart. Valid until shinyapps.io is switched off.
+
+## Verify after cutover
+
+- App reachable at its Connect Cloud URL, and the old shinyapps.io URL redirects.
+- Footer timestamp updates after a scheduler cycle (proves the bundled
+  `data/Ergebnis.Rds` is being refreshed, not just cached).
+- All three leagues selectable and rendering heatmaps.
+
+## Open risk: deploy frequency
+
+The scheduler redeploys every 2 minutes from 14:45–22:45 — up to ~241 full
+bundle uploads per matchday. **Posit documents no deployment rate limit for
+Connect Cloud.** Watch the first matchday after cutover for throttling or
+rejected deploys.
+
+If throttling appears, the fix is to skip redeploys when results are unchanged:
+hash the saved `Ergebnis` objects and compare against the previous cycle before
+calling `deployApp()`. That is worth doing regardless — most cycles during a
+matchday produce identical output.
+```
+
+- [ ] **Step 4: Remove the dead shinyapps CI references**
+
+`docs/GITHUB_ACTIONS_CONFIG.md:14-16,127-130` tells operators to set
+`SHINYAPPS_IO_*` as GitHub secrets, but no workflow reads them — deployment is
+operator-run from inside the container (confirmed as deliberate in
+`docs/superpowers/specs/2026-05-02-ci-rebuild-design.md:24`). Delete those
+secret-setup instructions and replace them with a one-line pointer:
+
+```markdown
+Deployment credentials are **not** GitHub secrets — the container deploys at
+runtime. See [`docs/deployment/connect-cloud-migration.md`](deployment/connect-cloud-migration.md).
+```
+
+- [ ] **Step 5: Verify the docs are internally consistent**
+
+Run:
+
+```bash
+grep -rn "three required values" docs/ .env.example
+grep -rn "SHINYAPPS_IO" docs/ | grep -v connect-cloud-migration
+```
+
+Expected: the first returns nothing (the stale phrase is gone). The second
+should only show the env-var table in `docs/deployment/README.md` and the
+quick-start — every hit should describe shinyapps as one of two backends, not
+as the only one. Fix any that still read as unconditional.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .env.example docs/deployment/README.md docs/deployment/connect-cloud-migration.md docs/GITHUB_ACTIONS_CONFIG.md
+git commit -m "docs: add Connect Cloud cutover runbook and backend env vars
+
+Documents the SHINY_DEPLOY_TARGET switch, the service-account credential
+setup, rollback, and the undocumented-rate-limit risk from redeploying
+every 2 minutes. Also drops the GitHub-secrets instructions for
+SHINYAPPS_IO_*, which no workflow has ever read."
+```
+
+---
+
+### Task 6: Live verification against Connect Cloud
+
+**This task cannot be completed before the migration tool ships (September 2026) and requires real credentials.** It is the empirical answer to the three open questions in the spec. Do not mark the plan complete without it — every prior task is unverified against the real service.
+
+**Files:** none (verification only)
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-5.
+- Produces: a go/no-go decision on flipping the default backend.
+
+- [ ] **Step 1: Confirm rsconnect in the image supports Connect Cloud**
+
+Run:
+
+```bash
+docker run --rm league-simulator:latest Rscript -e '
+  cat("rsconnect:", as.character(packageVersion("rsconnect")), "\n")
+  cat("client credentials:", "connectCloudClientCredentials" %in% getNamespaceExports("rsconnect"), "\n")
+'
+```
+
+Expected: version >= 1.10.0 and `TRUE`. If `FALSE`, stop — Task 3's build assertion did not do its job.
+
+- [ ] **Step 2: Authenticate with real credentials**
+
+Run:
+
+```bash
+SHINY_DEPLOY_TARGET=connectcloud \
+CONNECT_CLOUD_CLIENT_ID=<real> \
+CONNECT_CLOUD_CLIENT_SECRET=<real> \
+Rscript -e 'source("RCode/updateShiny.R"); authenticate_connectcloud(); cat("auth OK\n")'
+```
+
+Expected: `auth OK` with no browser prompt. **If a browser opens or the call blocks waiting for input, the client-credentials path does not work as documented** — that invalidates the core assumption of this design. Record the exact error and re-evaluate before proceeding; the fallback is GitHub-backed deployment, which is a different design.
+
+- [ ] **Step 3: Perform one real deploy with live simulation data**
+
+Run a single scheduler cycle against Connect Cloud, or deploy the existing
+bundle directly:
+
+```bash
+SHINY_DEPLOY_TARGET=connectcloud \
+CONNECT_CLOUD_CLIENT_ID=<real> CONNECT_CLOUD_CLIENT_SECRET=<real> \
+Rscript -e '
+  source("RCode/updateShiny.R")
+  load("ShinyApp/data/Ergebnis.Rds")
+  updateShiny(Ergebnis, Ergebnis2, Ergebnis3, Ergebnis3_Aufstieg,
+              directory = file.path(getwd(), "ShinyApp"))
+'
+```
+
+Expected: deploy succeeds and prints a Connect Cloud URL.
+
+- [ ] **Step 4: Verify the deployed app in a browser**
+
+Open the Connect Cloud URL and confirm: all three leagues render heatmaps, the
+footer timestamp matches this deploy, and no "Noch keine Prognosedaten
+verfügbar" panel appears (which would mean the bundled `data/Ergebnis.Rds` did
+not ship).
+
+- [ ] **Step 5: Probe the deploy-frequency risk**
+
+Run three consecutive deploys and time them:
+
+```bash
+for i in 1 2 3; do
+  echo "--- deploy $i ---"
+  time SHINY_DEPLOY_TARGET=connectcloud \
+    CONNECT_CLOUD_CLIENT_ID=<real> CONNECT_CLOUD_CLIENT_SECRET=<real> \
+    Rscript -e 'source("RCode/updateShiny.R"); load("ShinyApp/data/Ergebnis.Rds"); updateShiny(Ergebnis, Ergebnis2, Ergebnis3, Ergebnis3_Aufstieg, directory = file.path(getwd(), "ShinyApp"))'
+done
+```
+
+Expected: three successes with no throttling error and no growing delay. If any
+deploy is rejected or rate-limited, implement the hash-gated redeploy described
+in `docs/deployment/connect-cloud-migration.md` before cutting over.
+
+- [ ] **Step 6: Flip the default and record the outcome**
+
+Only after Steps 1-5 pass: set `SHINY_DEPLOY_TARGET=connectcloud` in the
+production `.env`, restart, and monitor the first live matchday. Then update
+`docs/deployment/connect-cloud-migration.md` with what the rate-limit probe
+actually showed, replacing the "Open risk" section with measured facts.
+
+```bash
+git add docs/deployment/connect-cloud-migration.md
+git commit -m "docs: record measured Connect Cloud deploy behaviour after cutover"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** Backend seam → Task 1. `on.exit` fix → Task 1, locked by Task 2. Hardcoded-path fix → Task 1. rsconnect >= 1.10.0 pin → Task 3. Scheduler preflight incl. the unchecked token → Task 4. Test strategy (both backends, unknown target, default unchanged, CWD restore) → Tasks 1, 2, 4. Docs/runbook → Task 5. The three open questions → Task 6 Steps 2 and 5. Rate-limit mitigation is specified concretely (hash-gated redeploy) rather than left vague.
+
+**Naming consistency:** `resolve_deploy_backend()`, `authenticate_shinyapps()`, `authenticate_connectcloud()`, `validate_deploy_credentials()` are defined in Tasks 1 and 4 and used with identical names in Tasks 4, 5, and 6. Env vars `SHINY_DEPLOY_TARGET`, `CONNECT_CLOUD_CLIENT_ID`, `CONNECT_CLOUD_CLIENT_SECRET`, `CONNECT_CLOUD_ACCOUNT` are spelled identically throughout.
+
+**Known deviation from strict TDD:** Task 2's test is written after its fix (the fix lands in Task 1, where the file is already being rewritten). Step 3 compensates with an explicit revert-and-observe-the-failure check, so the test is still proven to guard the behaviour.
+
+**Blocked-by-external-dependency:** Task 6 cannot run until the migration tool exists and credentials are issued. Tasks 1-5 are complete and mergeable without it; they are inert in production because the default backend is unchanged.

--- a/docs/superpowers/plans/2026-07-26-static-site-generation.md
+++ b/docs/superpowers/plans/2026-07-26-static-site-generation.md
@@ -1,0 +1,1328 @@
+# Static Site Generation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the shinyapps.io-hosted Shiny app with three statically pre-rendered pages produced by the simulator itself, served from the operator's existing homelab.
+
+**Architecture:** Extract the three rendering primitives out of `ShinyApp/app.R` into `RCode/render_helpers.R`, then add `RCode/generate_static_site.R` which writes `index.html`, `2-bundesliga.html`, `3-liga.html` and PNG heatmaps into an output directory. Swap the `updateShiny()` call in the scheduler loop for `generate_static_site()`. The Shiny app stays on disk as a rollback path.
+
+**Tech Stack:** R 4.6, `ggplot2`, `reshape2`, `htmltools` (already a dependency), `testthat` 3.2.3, `withr` 3.0.2.
+
+## Global Constraints
+
+- **No new dependencies.** `htmltools` is already in `packagelist.txt:24`; use it for HTML escaping and tag construction. Do not add `rmarkdown`, `knitr`, or `quarto`.
+- **`rsconnect` and `shiny` are not required at runtime** by any new code. Do not `library(shiny)` in the generator.
+- **Reuse, don't reimplement:** `display_result()`, `prozent()`, `groupResultsDF()` move verbatim from `ShinyApp/app.R`. Changing their behaviour would break `tests/testthat/test-prozent.R`.
+- **Preserve exactly:** the DST-aware footer (`MESZ` when `updatetime$isdst > 0`, else `MEZ`), the 24-hour stale banner, the "Noch keine Prognosedaten verfügbar" fallback, the title "Fußball-Prognosen von 30Punkte", and the `30punkte.wordpress.com` link.
+- **The three leagues are asymmetric.** 3. Liga's top table uses `Ergebnis3_Aufstieg`; its bottom table and heatmap use `Ergebnis3`. Full table in the spec — copy values from there, do not infer.
+- Data shapes: `Ergebnis` 18×18, `Ergebnis2` 18×18, `Ergebnis3` 20×20, `Ergebnis3_Aufstieg` 20×20, all class `table`.
+- Output dir env var: `STATIC_SITE_DIR`, default `ShinyApp/public`.
+- Run the full suite with `Rscript -e 'source("tests/testthat.R")'`; a single file with `Rscript -e 'testthat::test_file("tests/testthat/<file>.R")'`.
+- `ShinyApp/app.R` must keep working until Task 6 signs off. Do not delete it.
+
+## File Structure
+
+| File | Responsibility | Change |
+|---|---|---|
+| `RCode/render_helpers.R` | `display_result`, `prozent`, `groupResultsDF` — shared rendering primitives | Create (moved from `app.R`) |
+| `ShinyApp/app.R` | Shiny UI; sources the shared helpers instead of defining them | Modify |
+| `RCode/league_views.R` | Per-league config: sources, filters, labels, group matrices | Create |
+| `RCode/generate_static_site.R` | Renders PNGs + HTML pages to the output directory | Create |
+| `RCode/update_all_leagues_loop.R` | Call `generate_static_site()` instead of `updateShiny()` | Modify lines 163-169 |
+| `tests/testthat/test-render-helpers-move.R` | Regression: helpers still behave after the move | Create |
+| `tests/testthat/test-league-views.R` | Per-league config correctness, incl. the 3. Liga asymmetry | Create |
+| `tests/testthat/test-generate-static-site.R` | Output files, nav, footer, stale banner, fallback, determinism | Create |
+| `docs/deployment/static-site.md` | Operator runbook: web server, volume, cutover, rollback | Create |
+
+---
+
+### Task 1: Extract rendering helpers out of `app.R`
+
+Pure move, no behaviour change. Unlocks reuse by the generator and ends the situation where tested functions live inside a Shiny app file.
+
+**Files:**
+- Create: `RCode/render_helpers.R`
+- Modify: `ShinyApp/app.R:31-122` (remove the three functions), `ShinyApp/app.R:17` (add source)
+- Test: `tests/testthat/test-render-helpers-move.R`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `display_result(result, colour = "grey", low = "white", high = "steelblue", Titel = "Endplatzierung", labeling = FALSE, Teams = 18)` → a ggplot object.
+  - `prozent(x)` → numeric, or a tick character `intToUtf8(0x2713)` at exactly 1, `">99"` above .99, `"<1"` below .01.
+  - `groupResultsDF(results, labels, groups)` → data.frame with `length(labels)` columns, rownames preserved from `results`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/testthat/test-render-helpers-move.R`:
+
+```r
+# The rendering primitives moved out of ShinyApp/app.R into
+# RCode/render_helpers.R so the static site generator can reuse them.
+# These assertions pin the behaviour across the move.
+
+source_render_helpers <- function() {
+  source(test_path("..", "..", "RCode", "render_helpers.R"), local = TRUE)
+  environment()
+}
+
+test_that("render_helpers.R defines all three primitives", {
+  env <- source_render_helpers()
+  expect_true(is.function(env$display_result))
+  expect_true(is.function(env$prozent))
+  expect_true(is.function(env$groupResultsDF))
+})
+
+test_that("prozent keeps its boundary behaviour after the move", {
+  env <- source_render_helpers()
+  expect_equal(env$prozent(0), 0)
+  expect_equal(env$prozent(0.5), 50)
+  expect_equal(env$prozent(1), intToUtf8(0x2713))
+  expect_equal(env$prozent(0.995), ">99")
+  expect_equal(env$prozent(0.001), "<1")
+  expect_equal(env$prozent("text"), "text")
+})
+
+test_that("groupResultsDF sums column ranges and preserves rownames", {
+  env <- source_render_helpers()
+  m <- matrix(0.1, nrow = 2, ncol = 4,
+              dimnames = list(c("AAA", "BBB"), NULL))
+  out <- env$groupResultsDF(m, labels = c("first", "rest"),
+                            groups = cbind(c(1, 1), c(2, 4)))
+  expect_equal(colnames(out), c("first", "rest"))
+  expect_equal(rownames(out), c("AAA", "BBB"))
+  expect_equal(out$first, c(0.1, 0.1))
+  expect_equal(out$rest, c(0.3, 0.3), tolerance = 1e-8)
+})
+
+test_that("display_result returns a ggplot for a probability table", {
+  env <- source_render_helpers()
+  m <- matrix(1 / 18, nrow = 18, ncol = 18,
+              dimnames = list(paste0("T", 1:18), NULL))
+  p <- env$display_result(m, Titel = "Test", Teams = 18)
+  expect_s3_class(p, "ggplot")
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `Rscript -e 'testthat::test_file("tests/testthat/test-render-helpers-move.R")'`
+
+Expected: FAIL — `RCode/render_helpers.R` does not exist, so `source()` errors with "cannot open file".
+
+- [ ] **Step 3: Create `RCode/render_helpers.R`**
+
+Move lines 31-122 of `ShinyApp/app.R` verbatim into the new file, with a header. The bodies must not change — only their location.
+
+```r
+# Rendering primitives shared by the Shiny app (ShinyApp/app.R) and the static
+# site generator (RCode/generate_static_site.R).
+#
+# Requires: ggplot2, reshape2 (melt).
+
+display_result <- function (result, colour = "grey",
+                            low = "white", high = "steelblue",
+                            Titel = "Endplatzierung",
+                            labeling = FALSE, Teams = 18)
+
+  # Displays results from SimWrapper in a heatmap
+  # result : results to display
+  # colour : background colour for tiles
+  # low : colour for lower end of scale
+  # high : colour for higher end of scale
+  # Titel : text of the title line of the chart
+  # labeling : boolean, if true the tiles of the heatmap
+  #            are labeled with the values in percent
+
+{
+
+  if (labeling)
+  {
+    result <- round(result*100,0)
+  }
+
+  result.m <- melt (result)
+  plot <- ggplot (result.m) +
+    aes (Var1, Var2) +
+    geom_tile(aes (fill=value),
+              colour = colour) +
+    scale_fill_gradient (low = low, high = high,
+                         name = "p") +
+    labs (x = "Verein", y = "Platz") +
+    ggtitle (Titel) +
+    theme_grey()
+  plot <- plot +
+    theme (axis.text.x = element_text (size = rel (0.8), angle = 330,
+                                       hjust = 0, colour = "grey50"))
+  plot <- plot +
+    theme (axis.ticks = element_line (linetype = 0)) +
+    scale_y_reverse(breaks = 1:Teams)
+
+  if (labeling)
+  {
+    plot <- plot + geom_text (aes (label = value))
+  }
+
+
+  return (plot)
+}
+
+prozent <- function (x) {
+  if (!is.numeric(x)) {return (x)}
+  if ((x >= .01) && (x <= .99)) {
+    return (round (100 * x, digits = 0))
+  } else if (x == 1) {
+    return (intToUtf8(0x2713)) # Tick mark instead of 100 percent
+  } else if (x == 0) {
+    return (0)
+  } else if (x > 0.99) {
+    return (">99")
+  } else if (x < 0.01) {
+    return ("<1")
+  }
+}
+
+groupResultsDF <- function (results,
+                            labels = c("Meister", "Champions League", "Europa League",
+                                       "Conference League Quali", "Mittelfeld", "Relegation", "Abstieg"),
+                            groups = cbind(c(1,1), c(2,4), c(5,5),
+                                           c(6,6), c(7,15), c(16,16), c(17,18))) {
+
+  # groups results into a data frame of labeled groups
+  # results : data frame with n probabilities for n teams
+  # labels : vector of strings, labels for the groups
+  # groups : 2xn matrix of integers, lower and upper bounds for groups
+
+  outputDF <- data.frame (matrix(ncol=length(labels), nrow=dim(results)[1]))
+  colnames (outputDF) <- labels
+  rownames (outputDF) <- rownames (results)
+
+  for (i in 1:length(labels)) {
+    lower <- groups [1,i]
+    upper <- groups [2,i]
+    if (lower == upper) {
+      newcol <- results[,lower]
+    } else {
+      range <- c(lower:upper)
+      newcol <- rowSums(results[, range])
+    }
+    outputDF[,i] <- newcol
+
+  }
+
+  return (outputDF)
+}
+```
+
+Note the test calls `display_result` with a plain `matrix`, and `melt()` on a matrix yields `Var1`/`Var2` columns — matching the existing behaviour with `table` inputs.
+
+- [ ] **Step 4: Remove the moved functions from `ShinyApp/app.R` and source the new file**
+
+Delete `ShinyApp/app.R` lines 31-122 (the three function definitions). Then change line 17 from:
+
+```r
+source("app_helpers.R", local = TRUE)
+```
+
+to:
+
+```r
+source("app_helpers.R", local = TRUE)
+source("../RCode/render_helpers.R", local = TRUE)
+```
+
+The relative path works when the app is run from `ShinyApp/` (as `shiny::runApp("ShinyApp/app.R")` and the old `updateShiny()` `setwd()` both do). The app is now a local development tool only — it is no longer deployed, so bundling concerns do not apply.
+
+- [ ] **Step 5: Run the new test and the full suite**
+
+Run: `Rscript -e 'testthat::test_file("tests/testthat/test-render-helpers-move.R")'`
+Expected: all four tests PASS.
+
+Run: `Rscript -e 'source("tests/testthat.R")'`
+Expected: no new failures. `test-prozent.R` and `test-shiny-app-helpers.R` are the regression net — if either fails, the move was not verbatim.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add RCode/render_helpers.R ShinyApp/app.R tests/testthat/test-render-helpers-move.R
+git commit -m "refactor: extract rendering primitives from app.R into RCode/render_helpers.R
+
+display_result, prozent and groupResultsDF were defined inside the Shiny
+app but are needed by the static site generator. Pure move, no behaviour
+change; test-prozent.R is the regression net."
+```
+
+---
+
+### Task 2: Per-league view configuration
+
+The three leagues differ in data source, filter columns, labels and group matrices — and 3. Liga mixes two data objects. Isolating this as data makes the asymmetry reviewable and testable instead of buried in branching code.
+
+**Files:**
+- Create: `RCode/league_views.R`
+- Test: `tests/testthat/test-league-views.R`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `league_views()` → named list of three entries, keys `bundesliga`, `zweite_bundesliga`, `dritte_liga`. Each entry is a list with fields:
+  - `slug` (character): output filename without extension — `"index"`, `"2-bundesliga"`, `"3-liga"`
+  - `nav_label` (character): `"Bundesliga"`, `"2. Bundesliga"`, `"3. Liga"`
+  - `plot_title` (character), `teams` (integer)
+  - `plot_source` (character): name of the data object for the heatmap
+  - `top` / `bottom` (list): `source`, `filter_cols` (integer vector), `labels` (character vector), `groups` (matrix)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/testthat/test-league-views.R`:
+
+```r
+# Per-league configuration. The leagues are asymmetric: 3. Liga's promotion
+# table comes from Ergebnis3_Aufstieg while its relegation table and heatmap
+# come from Ergebnis3. These assertions pin that down.
+
+source_league_views <- function() {
+  source(test_path("..", "..", "RCode", "league_views.R"), local = TRUE)
+  environment()$league_views
+}
+
+test_that("league_views defines exactly the three leagues", {
+  views <- source_league_views()()
+  expect_named(views, c("bundesliga", "zweite_bundesliga", "dritte_liga"))
+})
+
+test_that("Bundesliga is the canonical index page", {
+  v <- source_league_views()()$bundesliga
+  expect_equal(v$slug, "index")
+  expect_equal(v$nav_label, "Bundesliga")
+  expect_equal(v$plot_source, "Ergebnis")
+  expect_equal(v$teams, 18)
+  expect_equal(v$top$labels,
+               c("Meister", "Champions League", "Europa League",
+                 "Conference League Quali"))
+  expect_equal(v$top$filter_cols, 1:6)
+  expect_equal(v$bottom$labels, c("Relegation", "Abstieg"))
+  expect_equal(v$bottom$filter_cols, 16:18)
+})
+
+test_that("2. Bundesliga uses Ergebnis2 for every panel", {
+  v <- source_league_views()()$zweite_bundesliga
+  expect_equal(v$slug, "2-bundesliga")
+  expect_equal(v$plot_source, "Ergebnis2")
+  expect_equal(v$top$source, "Ergebnis2")
+  expect_equal(v$bottom$source, "Ergebnis2")
+  expect_equal(v$top$labels, c("Aufstieg", "Relegation Bundesliga"))
+  expect_equal(v$top$filter_cols, 1:3)
+})
+
+test_that("3. Liga draws its top table from Ergebnis3_Aufstieg but its bottom from Ergebnis3", {
+  v <- source_league_views()()$dritte_liga
+  expect_equal(v$slug, "3-liga")
+  expect_equal(v$teams, 20)
+  expect_equal(v$plot_source, "Ergebnis3")
+  expect_equal(v$top$source, "Ergebnis3_Aufstieg")
+  expect_equal(v$bottom$source, "Ergebnis3")
+  expect_equal(v$top$labels, c("Aufstieg", "Relegation", "DFB-Pokal"))
+  expect_equal(v$top$filter_cols, 1:4)
+  expect_equal(v$bottom$labels, "Abstieg")
+  expect_equal(v$bottom$filter_cols, 17:20)
+})
+
+test_that("group matrices have two rows and one column per label", {
+  views <- source_league_views()()
+  for (nm in names(views)) {
+    v <- views[[nm]]
+    for (panel in c("top", "bottom")) {
+      g <- v[[panel]]$groups
+      expect_equal(nrow(g), 2, info = paste(nm, panel))
+      expect_equal(ncol(g), length(v[[panel]]$labels), info = paste(nm, panel))
+      expect_true(all(g[1, ] <= g[2, ]), info = paste(nm, panel))
+    }
+  }
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `Rscript -e 'testthat::test_file("tests/testthat/test-league-views.R")'`
+
+Expected: FAIL — `RCode/league_views.R` does not exist.
+
+- [ ] **Step 3: Create `RCode/league_views.R`**
+
+Values transcribed from `ShinyApp/app.R:175-228`. Do not infer any of them.
+
+```r
+# Per-league view configuration for the static site.
+#
+# Transcribed from the Shiny server logic in ShinyApp/app.R. The leagues are
+# deliberately asymmetric: 3. Liga's promotion table is built from
+# Ergebnis3_Aufstieg, while its relegation table and heatmap use Ergebnis3.
+
+league_views <- function() {
+  list(
+    bundesliga = list(
+      slug = "index",
+      nav_label = "Bundesliga",
+      plot_title = "Saisonprognose Bundesliga",
+      plot_source = "Ergebnis",
+      teams = 18L,
+      top = list(
+        source = "Ergebnis",
+        filter_cols = 1:6,
+        labels = c("Meister", "Champions League", "Europa League",
+                   "Conference League Quali"),
+        groups = cbind(c(1, 1), c(2, 4), c(5, 5), c(6, 6))
+      ),
+      bottom = list(
+        source = "Ergebnis",
+        filter_cols = 16:18,
+        labels = c("Relegation", "Abstieg"),
+        groups = cbind(c(16, 16), c(17, 18))
+      )
+    ),
+    zweite_bundesliga = list(
+      slug = "2-bundesliga",
+      nav_label = "2. Bundesliga",
+      plot_title = "Saisonprognose 2. Bundesliga",
+      plot_source = "Ergebnis2",
+      teams = 18L,
+      top = list(
+        source = "Ergebnis2",
+        filter_cols = 1:3,
+        labels = c("Aufstieg", "Relegation Bundesliga"),
+        groups = cbind(c(1, 2), c(3, 3))
+      ),
+      bottom = list(
+        source = "Ergebnis2",
+        filter_cols = 16:18,
+        labels = c("Relegation 3. Liga", "Abstieg"),
+        groups = cbind(c(16, 16), c(17, 18))
+      )
+    ),
+    dritte_liga = list(
+      slug = "3-liga",
+      nav_label = "3. Liga",
+      plot_title = "Saisonprognose 3. Liga",
+      plot_source = "Ergebnis3",
+      teams = 20L,
+      top = list(
+        source = "Ergebnis3_Aufstieg",
+        filter_cols = 1:4,
+        labels = c("Aufstieg", "Relegation", "DFB-Pokal"),
+        groups = cbind(c(1, 2), c(3, 3), c(4, 4))
+      ),
+      bottom = list(
+        source = "Ergebnis3",
+        filter_cols = 17:20,
+        labels = "Abstieg",
+        groups = cbind(c(17, 20))
+      )
+    )
+  )
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `Rscript -e 'testthat::test_file("tests/testthat/test-league-views.R")'`
+Expected: all five tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add RCode/league_views.R tests/testthat/test-league-views.R
+git commit -m "feat: add per-league view configuration for the static site
+
+Extracts the asymmetric per-league table/plot config from the Shiny
+server branches into reviewable data, including 3. Liga's split between
+Ergebnis3_Aufstieg (promotion) and Ergebnis3 (relegation, heatmap)."
+```
+
+---
+
+### Task 3: Render one league page
+
+The core of the generator: given one league config and the loaded data, produce a PNG heatmap and an HTML page. Kept separate from the multi-page orchestration so it can be tested in isolation.
+
+**Files:**
+- Create: `RCode/generate_static_site.R`
+- Test: `tests/testthat/test-generate-static-site.R`
+
+**Interfaces:**
+- Consumes: `league_views()` (Task 2); `display_result`, `prozent`, `groupResultsDF` (Task 1); `stale_warning_text`, `data_age_hours` from `ShinyApp/app_helpers.R`.
+- Produces:
+  - `render_panel_table(data_obj, panel)` → character HTML `<table>`; filters rows by `rowSums(data_obj[, panel$filter_cols]) >= 0.01`, groups via `groupResultsDF`, formats via `prozent`.
+  - `footer_timestamp(mtime)` → character like `"Letztes Update: 26.07.2026 14:30 MESZ"`.
+  - `render_league_page(view, data_env, output_dir, now)` → invisible path of the written HTML file; also writes `assets/<slug>.png`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/testthat/test-generate-static-site.R`:
+
+```r
+# Static site generation. Uses the real committed fixture shape (18x18, 18x18,
+# 20x20, 20x20 probability tables) so the tests exercise realistic data.
+
+source_generator <- function() {
+  source(test_path("..", "..", "RCode", "generate_static_site.R"), local = TRUE)
+  environment()
+}
+
+# Build a data environment with the same object names and shapes as the
+# production ShinyApp/data/Ergebnis.Rds.
+make_data_env <- function() {
+  env <- new.env()
+  mk <- function(n, teams) {
+    m <- matrix(1 / n, nrow = teams, ncol = n,
+                dimnames = list(paste0("T", seq_len(teams)), NULL))
+    as.table(m)
+  }
+  env$Ergebnis <- mk(18, 18)
+  env$Ergebnis2 <- mk(18, 18)
+  env$Ergebnis3 <- mk(20, 20)
+  env$Ergebnis3_Aufstieg <- mk(20, 20)
+  env
+}
+
+test_that("footer_timestamp labels summer time MESZ", {
+  gen <- source_generator()
+  ts <- as.POSIXct("2026-07-26 14:30:00", tz = "Europe/Berlin")
+  expect_match(gen$footer_timestamp(ts), "MESZ")
+  expect_match(gen$footer_timestamp(ts), "26\\.07\\.2026 14:30")
+})
+
+test_that("footer_timestamp labels winter time MEZ", {
+  gen <- source_generator()
+  ts <- as.POSIXct("2026-01-15 14:30:00", tz = "Europe/Berlin")
+  expect_match(gen$footer_timestamp(ts), "MEZ")
+  expect_false(grepl("MESZ", gen$footer_timestamp(ts)))
+})
+
+test_that("render_panel_table emits one column per label", {
+  gen <- source_generator()
+  views <- gen$league_views()
+  env <- make_data_env()
+  html <- gen$render_panel_table(env$Ergebnis, views$bundesliga$top)
+
+  for (lbl in views$bundesliga$top$labels) {
+    expect_true(grepl(lbl, html, fixed = TRUE), info = lbl)
+  }
+  expect_match(html, "<table")
+})
+
+test_that("render_league_page writes an HTML file and a PNG asset", {
+  gen <- source_generator()
+  out <- withr::local_tempdir()
+  env <- make_data_env()
+  view <- gen$league_views()$bundesliga
+
+  path <- gen$render_league_page(
+    view, env, out,
+    now = as.POSIXct("2026-07-26 14:30:00", tz = "Europe/Berlin")
+  )
+
+  expect_true(file.exists(path))
+  expect_equal(basename(path), "index.html")
+  expect_true(file.exists(file.path(out, "assets", "index.png")))
+
+  html <- paste(readLines(path, warn = FALSE), collapse = "\n")
+  expect_true(grepl("Saisonprognose Bundesliga", html, fixed = TRUE))
+  expect_true(grepl("Fußball-Prognosen von 30Punkte", html, fixed = TRUE))
+  expect_true(grepl("30punkte.wordpress.com", html, fixed = TRUE))
+})
+
+test_that("every page carries links to all three leagues", {
+  gen <- source_generator()
+  out <- withr::local_tempdir()
+  env <- make_data_env()
+  now <- as.POSIXct("2026-07-26 14:30:00", tz = "Europe/Berlin")
+
+  for (view in gen$league_views()) {
+    path <- gen$render_league_page(view, env, out, now = now)
+    html <- paste(readLines(path, warn = FALSE), collapse = "\n")
+    expect_true(grepl("index.html", html, fixed = TRUE), info = view$slug)
+    expect_true(grepl("2-bundesliga.html", html, fixed = TRUE), info = view$slug)
+    expect_true(grepl("3-liga.html", html, fixed = TRUE), info = view$slug)
+  }
+})
+
+test_that("3. Liga page is built from Ergebnis3_Aufstieg on top and Ergebnis3 below", {
+  gen <- source_generator()
+  out <- withr::local_tempdir()
+  env <- make_data_env()
+
+  # Make the two sources distinguishable: give Ergebnis3_Aufstieg a team name
+  # that appears nowhere in Ergebnis3.
+  rownames(env$Ergebnis3_Aufstieg)[1] <- "AUFSTIEGONLY"
+  rownames(env$Ergebnis3)[1] <- "ABSTIEGONLY"
+
+  path <- gen$render_league_page(
+    gen$league_views()$dritte_liga, env, out,
+    now = as.POSIXct("2026-07-26 14:30:00", tz = "Europe/Berlin")
+  )
+  html <- paste(readLines(path, warn = FALSE), collapse = "\n")
+
+  expect_true(grepl("AUFSTIEGONLY", html, fixed = TRUE))
+  expect_true(grepl("ABSTIEGONLY", html, fixed = TRUE))
+})
+
+test_that("a stale timestamp produces the warning banner", {
+  gen <- source_generator()
+  out <- withr::local_tempdir()
+  env <- make_data_env()
+  now <- as.POSIXct("2026-07-26 14:30:00", tz = "Europe/Berlin")
+
+  path <- gen$render_league_page(
+    gen$league_views()$bundesliga, env, out,
+    now = now, mtime = now - as.difftime(30, units = "hours")
+  )
+  html <- paste(readLines(path, warn = FALSE), collapse = "\n")
+  expect_true(grepl("werden derzeit nicht aktualisiert", html, fixed = TRUE))
+})
+
+test_that("a fresh timestamp produces no warning banner", {
+  gen <- source_generator()
+  out <- withr::local_tempdir()
+  env <- make_data_env()
+  now <- as.POSIXct("2026-07-26 14:30:00", tz = "Europe/Berlin")
+
+  path <- gen$render_league_page(
+    gen$league_views()$bundesliga, env, out,
+    now = now, mtime = now - as.difftime(1, units = "hours")
+  )
+  html <- paste(readLines(path, warn = FALSE), collapse = "\n")
+  expect_false(grepl("werden derzeit nicht aktualisiert", html, fixed = TRUE))
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `Rscript -e 'testthat::test_file("tests/testthat/test-generate-static-site.R")'`
+
+Expected: FAIL — `RCode/generate_static_site.R` does not exist.
+
+- [ ] **Step 3: Create `RCode/generate_static_site.R`**
+
+```r
+# Static site generation.
+#
+# Renders the three league views to self-contained HTML pages plus PNG heatmaps.
+# Replaces the shinyapps.io deployment: the simulator writes these files after
+# each cycle and any web server serves the directory.
+
+library(ggplot2)
+library(reshape2)
+
+# Resolve sibling modules relative to this file so the generator works from any
+# working directory.
+.gss_dir <- tryCatch(dirname(sys.frame(1)$ofile), error = function(e) "RCode")
+if (is.null(.gss_dir) || is.na(.gss_dir)) .gss_dir <- "RCode"
+
+source(file.path(.gss_dir, "render_helpers.R"), local = TRUE)
+source(file.path(.gss_dir, "league_views.R"), local = TRUE)
+source(file.path(.gss_dir, "..", "ShinyApp", "app_helpers.R"), local = TRUE)
+
+BLOG_URL <- "http://30punkte.wordpress.com"
+SITE_TITLE <- "Fußball-Prognosen von 30Punkte"
+
+footer_timestamp <- function(mtime) {
+  lt <- as.POSIXlt(mtime, tz = "Europe/Berlin")
+  # isdst: >0 = DST (MESZ), 0 = standard (MEZ), <0 = unknown -> falls through to MEZ
+  tzlabel <- if (lt$isdst > 0) "MESZ" else "MEZ"
+  paste0("Letztes Update: ", format(lt, "%d.%m.%Y %H:%M"), " ", tzlabel)
+}
+
+render_panel_table <- function(data_obj, panel) {
+  keep <- rowSums(data_obj[, panel$filter_cols, drop = FALSE]) >= 0.01
+  subset_obj <- data_obj[keep, , drop = FALSE]
+
+  if (nrow(subset_obj) == 0) {
+    return("")
+  }
+
+  grouped <- groupResultsDF(subset_obj,
+                            labels = panel$labels,
+                            groups = panel$groups)
+  formatted <- apply(grouped, c(1, 2), prozent)
+
+  # apply() drops to a vector when there is a single label column; restore shape.
+  if (is.null(dim(formatted))) {
+    formatted <- matrix(formatted, ncol = length(panel$labels),
+                        dimnames = list(rownames(grouped), panel$labels))
+  }
+
+  cells <- apply(formatted, 1, function(row) {
+    paste0("<td>", htmltools::htmlEscape(as.character(row)), "</td>",
+           collapse = "")
+  })
+
+  rows <- paste0(
+    "<tr><th scope=\"row\">",
+    htmltools::htmlEscape(rownames(formatted)), "</th>",
+    cells, "</tr>",
+    collapse = "\n"
+  )
+
+  paste0(
+    "<table>\n<thead><tr><th></th>",
+    paste0("<th>", htmltools::htmlEscape(panel$labels), "</th>", collapse = ""),
+    "</tr></thead>\n<tbody>\n", rows, "\n</tbody>\n</table>"
+  )
+}
+
+.nav_html <- function(current_slug, views) {
+  items <- vapply(views, function(v) {
+    label <- htmltools::htmlEscape(v$nav_label)
+    if (identical(v$slug, current_slug)) {
+      paste0("<span class=\"nav-current\">", label, "</span>")
+    } else {
+      paste0("<a href=\"", v$slug, ".html\">", label, "</a>")
+    }
+  }, character(1))
+  paste0("<nav>", paste(items, collapse = " · "), "</nav>")
+}
+
+.page_css <- paste(
+  "body{font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;",
+  "margin:0 auto;max-width:1000px;padding:1rem;line-height:1.5}",
+  "nav{margin:1rem 0}nav a{margin-right:.25rem}",
+  ".nav-current{font-weight:700;text-decoration:underline}",
+  "table{border-collapse:collapse;margin:1rem 0;width:100%}",
+  "th,td{border:1px solid #ddd;padding:.3rem .5rem;text-align:right}",
+  "th[scope=row]{text-align:left}",
+  "img{max-width:100%;height:auto}",
+  ".stale{background-color:#f8d7da;color:#721c24;padding:10px;",
+  "border-radius:4px;margin-bottom:12px}",
+  "footer{margin-top:2rem;font-size:.9rem;color:#555}",
+  sep = ""
+)
+
+render_league_page <- function(view, data_env, output_dir,
+                               now = Sys.time(), mtime = now) {
+  dir.create(file.path(output_dir, "assets"), recursive = TRUE,
+             showWarnings = FALSE)
+
+  plot_obj <- get(view$plot_source, envir = data_env)
+  png_rel <- file.path("assets", paste0(view$slug, ".png"))
+  ggplot2::ggsave(
+    filename = file.path(output_dir, png_rel),
+    plot = display_result(plot_obj, Titel = view$plot_title,
+                          Teams = view$teams),
+    width = 10, height = 6, dpi = 110
+  )
+
+  top_html <- render_panel_table(get(view$top$source, envir = data_env),
+                                 view$top)
+  bottom_html <- render_panel_table(get(view$bottom$source, envir = data_env),
+                                    view$bottom)
+
+  stale <- stale_warning_text(data_age_hours(mtime, now = now))
+  stale_html <- if (is.null(stale)) {
+    ""
+  } else {
+    paste0("<div class=\"stale\">", htmltools::htmlEscape(stale), "</div>")
+  }
+
+  html <- paste0(
+    "<!doctype html>\n<html lang=\"de\">\n<head>\n",
+    "<meta charset=\"utf-8\">\n",
+    "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">\n",
+    "<title>", htmltools::htmlEscape(SITE_TITLE), " – ",
+    htmltools::htmlEscape(view$nav_label), "</title>\n",
+    "<style>", .page_css, "</style>\n</head>\n<body>\n",
+    "<h1>", htmltools::htmlEscape(SITE_TITLE), "</h1>\n",
+    .nav_html(view$slug, league_views()), "\n",
+    stale_html, "\n",
+    "<img src=\"", png_rel, "\" alt=\"",
+    htmltools::htmlEscape(view$plot_title), "\">\n",
+    top_html, "\n", bottom_html, "\n",
+    "<footer>\n<p>Alle Prognosen als Wahrscheinlichkeiten in Prozent ",
+    "angegeben. Nähere Infos unter <a href=\"", BLOG_URL,
+    "\" target=\"blank_\">30punkte.wordpress.com</a></p>\n",
+    "<p>", htmltools::htmlEscape(footer_timestamp(mtime)), "</p>\n",
+    "</footer>\n</body>\n</html>\n"
+  )
+
+  out_path <- file.path(output_dir, paste0(view$slug, ".html"))
+  writeLines(html, out_path, useBytes = TRUE)
+  invisible(out_path)
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `Rscript -e 'testthat::test_file("tests/testthat/test-generate-static-site.R")'`
+
+Expected: all eight tests PASS. If the `render_panel_table` single-label case fails for 3. Liga's bottom table (`labels = "Abstieg"`), the `is.null(dim(formatted))` restore is the code path to check — `apply()` collapses to a vector there.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add RCode/generate_static_site.R tests/testthat/test-generate-static-site.R
+git commit -m "feat: render a league view to static HTML plus PNG heatmap
+
+Reuses display_result/prozent/groupResultsDF and the existing staleness
+helpers, so the static pages preserve the Shiny app's DST-aware footer,
+24h stale banner and table grouping."
+```
+
+---
+
+### Task 4: Orchestrate all three pages with a fallback
+
+Wraps the per-page renderer into the entry point the scheduler calls, including the "no data" degradation path the Shiny app had.
+
+**Files:**
+- Modify: `RCode/generate_static_site.R` (add the orchestrator)
+- Test: `tests/testthat/test-generate-static-site.R` (extend)
+
+**Interfaces:**
+- Consumes: `render_league_page()`, `league_views()` from Task 3.
+- Produces: `generate_static_site(Ergebnis, Ergebnis2, Ergebnis3, Ergebnis3_Aufstieg = Ergebnis3, output_dir = Sys.getenv("STATIC_SITE_DIR", "ShinyApp/public"), now = Sys.time())` → invisible character vector of written page paths. Writes a fallback `index.html` when data is missing.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/testthat/test-generate-static-site.R`:
+
+```r
+test_that("generate_static_site writes all three pages and their assets", {
+  gen <- source_generator()
+  out <- withr::local_tempdir()
+  env <- make_data_env()
+
+  paths <- gen$generate_static_site(
+    env$Ergebnis, env$Ergebnis2, env$Ergebnis3, env$Ergebnis3_Aufstieg,
+    output_dir = out,
+    now = as.POSIXct("2026-07-26 14:30:00", tz = "Europe/Berlin")
+  )
+
+  expect_length(paths, 3)
+  for (f in c("index.html", "2-bundesliga.html", "3-liga.html")) {
+    expect_true(file.exists(file.path(out, f)), info = f)
+  }
+  for (f in c("index.png", "2-bundesliga.png", "3-liga.png")) {
+    expect_true(file.exists(file.path(out, "assets", f)), info = f)
+  }
+})
+
+test_that("generate_static_site writes the fallback page when data is missing", {
+  gen <- source_generator()
+  out <- withr::local_tempdir()
+
+  paths <- gen$generate_static_site(
+    NULL, NULL, NULL, NULL, output_dir = out,
+    now = as.POSIXct("2026-07-26 14:30:00", tz = "Europe/Berlin")
+  )
+
+  expect_length(paths, 1)
+  html <- paste(readLines(file.path(out, "index.html"), warn = FALSE),
+                collapse = "\n")
+  expect_true(grepl("Noch keine Prognosedaten verfügbar", html, fixed = TRUE))
+  expect_true(grepl("30punkte.wordpress.com", html, fixed = TRUE))
+})
+
+test_that("generate_static_site output is deterministic for fixed inputs", {
+  gen <- source_generator()
+  env <- make_data_env()
+  now <- as.POSIXct("2026-07-26 14:30:00", tz = "Europe/Berlin")
+
+  out1 <- withr::local_tempdir()
+  out2 <- withr::local_tempdir()
+  gen$generate_static_site(env$Ergebnis, env$Ergebnis2, env$Ergebnis3,
+                           env$Ergebnis3_Aufstieg, output_dir = out1, now = now)
+  gen$generate_static_site(env$Ergebnis, env$Ergebnis2, env$Ergebnis3,
+                           env$Ergebnis3_Aufstieg, output_dir = out2, now = now)
+
+  for (f in c("index.html", "2-bundesliga.html", "3-liga.html")) {
+    expect_equal(
+      readLines(file.path(out1, f), warn = FALSE),
+      readLines(file.path(out2, f), warn = FALSE),
+      info = f
+    )
+  }
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `Rscript -e 'testthat::test_file("tests/testthat/test-generate-static-site.R")'`
+
+Expected: the eight Task 3 tests PASS; the three new ones FAIL because `generate_static_site` is not defined.
+
+- [ ] **Step 3: Add the orchestrator to `RCode/generate_static_site.R`**
+
+Append:
+
+```r
+.render_fallback_page <- function(output_dir) {
+  html <- paste0(
+    "<!doctype html>\n<html lang=\"de\">\n<head>\n",
+    "<meta charset=\"utf-8\">\n",
+    "<meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">\n",
+    "<title>", htmltools::htmlEscape(SITE_TITLE), "</title>\n",
+    "<style>", .page_css, "</style>\n</head>\n<body>\n",
+    "<h1>", htmltools::htmlEscape(SITE_TITLE), "</h1>\n",
+    "<h3>Noch keine Prognosedaten verfügbar</h3>\n",
+    "<p>Die Simulationsergebnisse wurden noch nicht erzeugt oder konnten ",
+    "nicht geladen werden. Bitte versuchen Sie es später erneut.</p>\n",
+    "<footer><p>Nähere Infos unter <a href=\"", BLOG_URL,
+    "\" target=\"blank_\">30punkte.wordpress.com</a></p></footer>\n",
+    "</body>\n</html>\n"
+  )
+  dir.create(output_dir, recursive = TRUE, showWarnings = FALSE)
+  out_path <- file.path(output_dir, "index.html")
+  writeLines(html, out_path, useBytes = TRUE)
+  invisible(out_path)
+}
+
+generate_static_site <- function(Ergebnis, Ergebnis2, Ergebnis3,
+                                 Ergebnis3_Aufstieg = Ergebnis3,
+                                 output_dir = Sys.getenv("STATIC_SITE_DIR",
+                                                         "ShinyApp/public"),
+                                 now = Sys.time()) {
+  have_data <- !is.null(Ergebnis) && !is.null(Ergebnis2) && !is.null(Ergebnis3)
+
+  if (!have_data) {
+    message("generate_static_site: no simulation data, writing fallback page")
+    return(invisible(.render_fallback_page(output_dir)))
+  }
+
+  data_env <- new.env(parent = emptyenv())
+  assign("Ergebnis", Ergebnis, envir = data_env)
+  assign("Ergebnis2", Ergebnis2, envir = data_env)
+  assign("Ergebnis3", Ergebnis3, envir = data_env)
+  assign("Ergebnis3_Aufstieg",
+         if (is.null(Ergebnis3_Aufstieg)) Ergebnis3 else Ergebnis3_Aufstieg,
+         envir = data_env)
+
+  dir.create(output_dir, recursive = TRUE, showWarnings = FALSE)
+
+  paths <- vapply(league_views(), function(view) {
+    message(sprintf("generate_static_site: rendering %s", view$slug))
+    render_league_page(view, data_env, output_dir, now = now, mtime = now)
+  }, character(1))
+
+  message(sprintf("generate_static_site: wrote %d pages to %s",
+                  length(paths), output_dir))
+  invisible(unname(paths))
+}
+```
+
+- [ ] **Step 4: Run the whole file and then the full suite**
+
+Run: `Rscript -e 'testthat::test_file("tests/testthat/test-generate-static-site.R")'`
+Expected: all eleven tests PASS.
+
+Run: `Rscript -e 'source("tests/testthat.R")'`
+Expected: no new failures.
+
+- [ ] **Step 5: Generate the site from the real committed fixture and inspect it**
+
+Run:
+
+```bash
+Rscript -e '
+  source("RCode/generate_static_site.R")
+  e <- new.env(); load("ShinyApp/data/Ergebnis.Rds", envir = e)
+  generate_static_site(e$Ergebnis, e$Ergebnis2, e$Ergebnis3, e$Ergebnis3_Aufstieg,
+                       output_dir = "ShinyApp/public")
+'
+ls -R ShinyApp/public
+```
+
+Expected: three HTML files and three PNGs. Open `ShinyApp/public/index.html` in a browser and confirm the heatmap renders, both tables appear, navigation switches between all three leagues, and the footer shows a plausible Berlin timestamp.
+
+- [ ] **Step 6: Ignore the generated output and commit**
+
+Add to `.gitignore`:
+
+```
+ShinyApp/public/
+```
+
+```bash
+git add RCode/generate_static_site.R tests/testthat/test-generate-static-site.R .gitignore
+git commit -m "feat: generate the full three-page static site
+
+Adds the generate_static_site() entry point with the no-data fallback
+page the Shiny app had, plus a determinism test so repeated cycles do not
+produce spurious diffs."
+```
+
+---
+
+### Task 5: Call the generator from the scheduler loop
+
+Switches production over. Small change, but it is the one that matters — keep the existing gate so behaviour on "no new simulation" is unchanged.
+
+**Files:**
+- Modify: `RCode/update_all_leagues_loop.R:59` (source) and `:163-169` (call site)
+- Test: `tests/testthat/test-update-loop-gating.R` (extend)
+
+**Interfaces:**
+- Consumes: `generate_static_site()` from Task 4.
+- Produces: no new API.
+
+- [ ] **Step 1: Read the current call site and its tests**
+
+Run:
+
+```bash
+sed -n '55,62p;160,172p' RCode/update_all_leagues_loop.R
+grep -n "updateShiny" tests/testthat/test-update-loop-gating.R
+```
+
+Note the existing gate `simulation_executed && !is.null(Ergebnis)` and how the test stubs `updateShiny` via `mockery::stub`. The stub target changes to `generate_static_site`.
+
+- [ ] **Step 2: Write the failing test**
+
+Add to `tests/testthat/test-update-loop-gating.R`, adapting to that file's existing setup helpers (it already builds a loop-invocation harness — reuse it rather than inventing a new one):
+
+```r
+test_that("the loop generates the static site when a simulation ran", {
+  called <- new.env()
+  called$n <- 0L
+
+  # Reuse this file's existing harness for invoking one loop iteration.
+  # Stub the generator and assert the gate still fires exactly once.
+  stub_generate <- function(...) {
+    called$n <- called$n + 1L
+    invisible(character(0))
+  }
+
+  run_one_loop_iteration(simulation_executed = TRUE,
+                         generate_static_site = stub_generate)
+  expect_equal(called$n, 1L)
+})
+
+test_that("the loop skips site generation when no simulation ran", {
+  called <- new.env()
+  called$n <- 0L
+  stub_generate <- function(...) {
+    called$n <- called$n + 1L
+    invisible(character(0))
+  }
+
+  run_one_loop_iteration(simulation_executed = FALSE,
+                         generate_static_site = stub_generate)
+  expect_equal(called$n, 0L)
+})
+```
+
+If `test-update-loop-gating.R` has no reusable `run_one_loop_iteration` helper, mirror the `mockery::stub` pattern already used at its lines 76, 107 and 137, swapping the stubbed function name from `updateShiny` to `generate_static_site`.
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `Rscript -e 'testthat::test_file("tests/testthat/test-update-loop-gating.R")'`
+
+Expected: the new tests FAIL — the loop still calls `updateShiny`, so the `generate_static_site` stub is never invoked.
+
+- [ ] **Step 4: Switch the call site**
+
+In `RCode/update_all_leagues_loop.R`, change the source on line 59 from:
+
+```r
+source("RCode/updateShiny.R")
+```
+
+to:
+
+```r
+source("RCode/generate_static_site.R")
+```
+
+and replace the call block at lines 163-169:
+
+```r
+      # Update Shiny if simulations have been executed
+      if (simulation_executed && !is.null(Ergebnis)) {
+        message(sprintf("Loop %d: Updating Shiny app with new results", i))
+        updateShiny(Ergebnis, Ergebnis2, Ergebnis3, Ergebnis3_Aufstieg, directory = shiny_directory)
+      } else {
+        message(sprintf("Loop %d: No updates needed, skipping Shiny deployment", i))
+      }
+```
+
+with:
+
+```r
+      # Regenerate the static site if simulations have been executed
+      if (simulation_executed && !is.null(Ergebnis)) {
+        message(sprintf("Loop %d: Regenerating static site with new results", i))
+        generate_static_site(Ergebnis, Ergebnis2, Ergebnis3, Ergebnis3_Aufstieg)
+      } else {
+        message(sprintf("Loop %d: No updates needed, skipping site generation", i))
+      }
+```
+
+`generate_static_site()` takes its output directory from `STATIC_SITE_DIR`, so the `shiny_directory` argument is no longer passed here. Check whether `shiny_directory` is still used elsewhere in the file (`updateScheduler.R:167-175` passes it in) — if it has become unused, leave the parameter in place for now and note it for the follow-up cleanup rather than changing the scheduler's signature in this task.
+
+- [ ] **Step 5: Run the tests and the full suite**
+
+Run: `Rscript -e 'testthat::test_file("tests/testthat/test-update-loop-gating.R")'`
+Expected: PASS, including the pre-existing gating tests.
+
+Run: `Rscript -e 'source("tests/testthat.R")'`
+Expected: no new failures. `tests/testthat/test-updateShiny-env.R` still passes because `RCode/updateShiny.R` is untouched and still on disk.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add RCode/update_all_leagues_loop.R tests/testthat/test-update-loop-gating.R
+git commit -m "feat: generate the static site instead of deploying to shinyapps.io
+
+The scheduler loop now writes local files rather than redeploying the
+whole app up to ~241 times per matchday. updateShiny.R stays on disk as
+the rollback path until the static site has served one full matchday."
+```
+
+---
+
+### Task 6: Operator runbook and cutover
+
+The deliverable that makes this usable: how to serve the directory, how to cut over, how to roll back, and when to cancel the subscription.
+
+**Files:**
+- Create: `docs/deployment/static-site.md`
+- Modify: `docker-compose.yml` (volume + `STATIC_SITE_DIR`), `.env.example`, `docs/deployment/README.md`, `README.md:5`
+
+**Interfaces:**
+- Consumes: `STATIC_SITE_DIR` from Task 4.
+- Produces: nothing consumed by code.
+
+- [ ] **Step 1: Expose the output directory from the container**
+
+In `docker-compose.yml`, add to the `league-simulator-integrated` service's `environment:` list (after line 13):
+
+```yaml
+      - STATIC_SITE_DIR=/app/ShinyApp/public
+```
+
+and add a volume so the host web server can read the generated files:
+
+```yaml
+    volumes:
+      - ./ShinyApp/public:/app/ShinyApp/public
+```
+
+The container runs as uid 1001 (per `Dockerfile:127-130`), so the host directory must be writable by that uid. Create it before first run:
+
+```bash
+mkdir -p ShinyApp/public && chmod 777 ShinyApp/public
+```
+
+- [ ] **Step 2: Document the env var**
+
+In `.env.example`, add under the optional block:
+
+```bash
+# STATIC_SITE_DIR=ShinyApp/public
+```
+
+In `docs/deployment/README.md`, add a row to the env-var table and remove the three `SHINYAPPS_IO_*` rows, replacing them with a pointer:
+
+```markdown
+| `STATIC_SITE_DIR` | no | `ShinyApp/public` | Output directory for the generated static site |
+```
+
+Note below the table: ShinyApps.io deployment has been replaced by static site generation — see [`static-site.md`](static-site.md).
+
+- [ ] **Step 3: Write the runbook**
+
+Create `docs/deployment/static-site.md`:
+
+```markdown
+# Static Site
+
+The simulator renders three pre-rendered pages after each simulation cycle and
+writes them to `STATIC_SITE_DIR` (default `ShinyApp/public`). Any web server
+serves that directory — there is no Shiny runtime, no `rsconnect`, and no
+deployment credentials.
+
+This replaced the shinyapps.io deployment. Background:
+[`docs/superpowers/specs/2026-07-26-static-site-generation-design.md`](../superpowers/specs/2026-07-26-static-site-generation-design.md).
+
+## Output
+
+```
+ShinyApp/public/
+├── index.html          # Bundesliga
+├── 2-bundesliga.html
+├── 3-liga.html
+└── assets/*.png
+```
+
+Total size is a few hundred KB. Writes are idempotent, so regenerating every
+2 minutes during a matchday costs nothing.
+
+## Serving it
+
+Caddy handles TLS automatically and is the shortest path:
+
+```caddyfile
+prognosen.example.org {
+    root * /srv/league-simulator/public
+    file_server
+    encode gzip
+}
+```
+
+If you would rather not expose a port, a Cloudflare Tunnel pointed at a local
+`file_server` works the same way.
+
+Point the web root at the host side of the compose volume
+(`./ShinyApp/public`).
+
+## Generating manually
+
+```bash
+Rscript -e '
+  source("RCode/generate_static_site.R")
+  e <- new.env(); load("ShinyApp/data/Ergebnis.Rds", envir = e)
+  generate_static_site(e$Ergebnis, e$Ergebnis2, e$Ergebnis3, e$Ergebnis3_Aufstieg)
+'
+```
+
+## Cutover
+
+1. Generate the site manually (above) and compare it against the live
+   shinyapps.io app — same probabilities, same team lists, same timestamp
+   behaviour.
+2. Point the web server at the output directory and confirm it serves publicly
+   over TLS.
+3. Run one full matchday with both paths active. The scheduler already generates
+   the static site; shinyapps.io stays live in parallel.
+4. Once satisfied, update the dashboard link in `README.md` and cancel the
+   shinyapps.io subscription. Do this well before **2027-03-31**, when Posit's
+   forced migration to Connect Cloud would otherwise apply.
+
+## Rollback
+
+`RCode/updateShiny.R` and `ShinyApp/app.R` remain on disk. To go back, restore
+the `updateShiny()` call in `RCode/update_all_leagues_loop.R` (see the commit
+that switched it) and ensure `SHINYAPPS_IO_TOKEN` / `SHINYAPPS_IO_SECRET` are
+still set.
+
+## Local preview
+
+`ShinyApp/app.R` still runs as a development tool:
+
+```bash
+Rscript -e 'shiny::runApp("ShinyApp/app.R")'
+```
+```
+
+- [ ] **Step 4: Update the dashboard link in `README.md`**
+
+`README.md:5` points at `https://chrisschwer.shinyapps.io/FussballPrognosen/`. Leave it until the static site is publicly served, then replace it with the new URL. Add a note now so it is not forgotten:
+
+```markdown
+Live dashboard: <https://chrisschwer.shinyapps.io/FussballPrognosen/>
+(migrating to a self-hosted static site — see docs/deployment/static-site.md)
+```
+
+- [ ] **Step 5: Verify the container writes to the mounted directory**
+
+Run:
+
+```bash
+mkdir -p ShinyApp/public && chmod 777 ShinyApp/public
+docker-compose up -d --build
+docker-compose exec league-simulator-integrated Rscript -e '
+  source("RCode/generate_static_site.R")
+  e <- new.env(); load("ShinyApp/data/Ergebnis.Rds", envir = e)
+  generate_static_site(e$Ergebnis, e$Ergebnis2, e$Ergebnis3, e$Ergebnis3_Aufstieg)
+'
+ls -l ShinyApp/public ShinyApp/public/assets
+```
+
+Expected: the three HTML files and three PNGs appear on the **host**, proving the volume and uid-1001 write permissions work. If writes fail with a permission error, fix the host directory ownership rather than running the container as root.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docker-compose.yml .env.example docs/deployment/README.md docs/deployment/static-site.md README.md
+git commit -m "docs: add static site runbook and expose the output directory
+
+Documents serving the generated pages (Caddy/Cloudflare Tunnel), the
+cutover sequence against the live Shiny app, and rollback. Adds the
+STATIC_SITE_DIR volume so the host web server can read the output."
+```
+
+---
+
+### Task 7: Retire the deployment path (after one clean matchday)
+
+**Do not start this until the static site has served one full matchday successfully.** Until then `updateShiny.R` is the rollback path.
+
+**Files:**
+- Delete: `RCode/updateShiny.R`, `tests/testthat/test-updateShiny-env.R`
+- Modify: `packagelist.txt` (drop `rsconnect` and its deploy-only deps), `Dockerfile:57,78`, `docker-compose.yml`, `.env.example`, `docs/deployment/README.md`, `docs/GITHUB_ACTIONS_CONFIG.md`
+
+**Interfaces:**
+- Consumes: a verified-working static site.
+- Produces: nothing.
+
+- [ ] **Step 1: Confirm nothing still references the deploy path**
+
+Run:
+
+```bash
+grep -rn "updateShiny\|rsconnect\|SHINYAPPS_IO" --include="*.R" --include="*.yml" --include="*.yaml" --include="Dockerfile" --include="*.txt" . | grep -v "^./docs/"
+```
+
+Expected: hits only in the files this task deletes or edits. If `RCode/updateScheduler.R` still passes `shiny_directory`, remove that argument now (deferred from Task 5 Step 4).
+
+- [ ] **Step 2: Delete the deployment module and its tests**
+
+```bash
+git rm RCode/updateShiny.R tests/testthat/test-updateShiny-env.R
+```
+
+- [ ] **Step 3: Drop the deploy-only dependencies**
+
+In `packagelist.txt`, remove `rsconnect` (line 14) and the block added solely for deployment — `crayon`, `ellipsis`, `httpuv` (lines 20-22) — along with the comment on line 19. Keep `shiny` only if you still want `app.R` runnable inside the container; if not, drop `shiny`, `htmltools`, `promises` and `DT` too.
+
+`htmltools` is used by `generate_static_site.R` — **keep it** regardless.
+
+In `Dockerfile`, remove `'rsconnect'` from the vectors on lines 57 and 78.
+
+- [ ] **Step 4: Remove the credentials from the runtime config**
+
+In `docker-compose.yml`, delete the three `SHINYAPPS_IO_*` environment lines (7-9). In `.env.example`, delete the `SHINYAPPS_IO_SECRET` / `SHINYAPPS_IO_TOKEN` / `SHINYAPPS_IO_NAME` entries. In `docs/deployment/README.md`, remove the corresponding table rows.
+
+In `docs/GITHUB_ACTIONS_CONFIG.md:14-16,127-130`, delete the `gh secret set SHINYAPPS_IO_*` instructions — no workflow ever read them (confirmed in `docs/superpowers/specs/2026-05-02-ci-rebuild-design.md:24`).
+
+- [ ] **Step 5: Rebuild and run the full suite**
+
+Run: `Rscript -e 'source("tests/testthat.R")'`
+Expected: PASS with the `updateShiny` tests gone and no new failures.
+
+Run: `docker build -t league-simulator:latest . && docker-compose up -d`
+Expected: build succeeds without `rsconnect`; the scheduler starts and generates the site.
+
+- [ ] **Step 6: Rotate the now-unused credentials and commit**
+
+Revoke the shinyapps.io token/secret in the Posit account (they are no longer needed and exist in local `.env` history), then cancel the subscription.
+
+```bash
+git add -A
+git commit -m "chore: retire the shinyapps.io deployment path
+
+The static site has served a full matchday, so updateShiny.R, its tests,
+rsconnect and the deploy-only dependencies come out. Credentials revoked
+and the subscription cancelled, so the 2027-03-31 forced migration to
+Connect Cloud no longer applies."
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** Helper extraction → Task 1. Per-league asymmetry incl. `Ergebnis3_Aufstieg`/`Ergebnis3` split → Task 2 (config) and Task 3 (rendering test that would catch a swap). Three pages + assets + nav → Tasks 3-4. DST footer → Task 3. Stale banner → Task 3. Fallback page → Task 4. Determinism → Task 4. Scheduler integration behind the existing gate → Task 5. Web server, volume, cutover, rollback → Task 6. Subscription cancellation before 2027-03-31 → Tasks 6 and 7. "Do not delete `app.R`" honoured — Task 7 removes only `updateShiny.R`, and gates even that on a clean matchday.
+
+**Naming consistency:** `league_views()`, `render_panel_table()`, `footer_timestamp()`, `render_league_page()`, `generate_static_site()` are defined in Tasks 2-4 and referenced with identical signatures in Tasks 5-7. Slugs `index` / `2-bundesliga` / `3-liga` are used identically in the config, the tests, the nav, and the runbook. `STATIC_SITE_DIR` is spelled the same in Tasks 4, 5 and 6.
+
+**Known risks flagged inline rather than hidden:** the `apply()` single-label collapse for 3. Liga's bottom table (Task 3 Step 4), uid-1001 write permission on the mounted volume (Task 6 Steps 1 and 5), and the possibly-absent `run_one_loop_iteration` harness in the existing gating test (Task 5 Step 2 gives the fallback pattern).
+
+**Deferred deliberately:** removing the now-unused `shiny_directory` parameter threads through `updateScheduler.R:167-175`; Task 5 leaves it and Task 7 Step 1 picks it up, so the risky change happens when the deploy path is already gone.

--- a/docs/superpowers/specs/2026-07-26-connect-cloud-migration-design.md
+++ b/docs/superpowers/specs/2026-07-26-connect-cloud-migration-design.md
@@ -1,0 +1,184 @@
+# Connect Cloud Migration — Design
+
+**Date:** 2026-07-26
+**Status:** Approved design, pending implementation
+**Trigger:** Posit email 2026-07-26 announcing shinyapps.io consolidation into Posit Connect Cloud
+
+## Problem
+
+Posit is retiring shinyapps.io in favour of Posit Connect Cloud. The account
+(`chrisschwer`, **Starter plan, 13 USD/month**) will be force-migrated on
+**2027-03-31** if not migrated voluntarily. A self-serve migration tool arrives
+September 2026.
+
+The Shiny application itself is unaffected — `ShinyApp/app.R` is a standard Shiny
+app and runs on Connect Cloud unchanged. The problem is exclusively in the
+**unattended deployment path**.
+
+`RCode/updateShiny.R:37` authenticates with a static token/secret pair:
+
+```r
+rsconnect::setAccountInfo(name = account_name, token = account_token, secret = account_secret)
+```
+
+`setAccountInfo()` targets shinyapps.io and does not exist for Connect Cloud.
+The publicised Connect Cloud replacement, `connectCloudUser()`, performs a
+**browser-based handshake** ("without worrying about API key management") and is
+therefore unusable from a headless container.
+
+### Why this breaks quietly
+
+The failure mode is the dangerous kind. `RCode/updateScheduler.R:6,16-18`
+preflights only `SHINYAPPS_IO_SECRET` at startup — never `SHINYAPPS_IO_TOKEN`.
+A broken deploy credential therefore surfaces hours later, inside the matchday
+loop, not at container start. Viewers keep seeing the redirected app while the
+data silently goes stale.
+
+`updateShiny.R:59` compounds this: `setwd(curr_wd)` is not wrapped in
+`on.exit()`, so a failing `deployApp()` leaves the process CWD inside
+`ShinyApp/`, breaking the *next* loop iteration's relative `source("RCode/...")`
+paths. A deploy-time error thus escalates into a scheduler-wide failure.
+
+## Solution
+
+Use `rsconnect::connectCloudClientCredentials()` — an OAuth 2.0
+`client_credentials` grant against a Connect Cloud **service account**,
+documented explicitly "to authenticate in non-interactive contexts".
+
+```r
+rsconnect::connectCloudClientCredentials(
+  clientId     = Sys.getenv("CONNECT_CLOUD_CLIENT_ID"),
+  clientSecret = Sys.getenv("CONNECT_CLOUD_CLIENT_SECRET"),
+  accountName  = Sys.getenv("CONNECT_CLOUD_ACCOUNT", "chrisschwer")
+)
+```
+
+This is a structural 1:1 replacement for the current pattern: three environment
+variables in, `deployApp()` unchanged afterwards. Credentials are issued at
+<https://login.posit.cloud/identity/credentials>.
+
+### Version constraint
+
+| Item | Value |
+|---|---|
+| `connectCloudClientCredentials` introduced | rsconnect **1.10.0** |
+| Locally installed at analysis time | rsconnect 1.5.0 (lacks the function) |
+| CRAN latest | rsconnect 1.10.1 |
+| `packagelist.txt:14` | bare `rsconnect` — **unpinned** |
+
+The unpinned dependency means the Docker build installs whichever version CRAN
+serves on build day. Pinning `rsconnect (>= 1.10.0)` is part of this migration,
+not an afterthought.
+
+### Plan mapping and cost
+
+Starter maps to Connect Cloud **Basic**, with current pricing and authorized
+user count held **until 2029**. Basic is also the tier that permits deployment
+from private GitHub repositories and offers higher memory than Free. Relevant
+detail: the **Free** plan deploys only from *public* GitHub repos, so the paid
+plan is not merely a convenience here — it underpins the chosen approach.
+
+## Architecture
+
+Introduce a thin **deployment backend seam** in `RCode/updateShiny.R`, selected
+by one environment variable:
+
+```
+SHINY_DEPLOY_TARGET = shinyapps | connectcloud     (default: shinyapps)
+```
+
+Two small functions behind one interface:
+
+- `authenticate_shinyapps()` — reads `SHINYAPPS_IO_{NAME,TOKEN,SECRET}`, calls `setAccountInfo()`
+- `authenticate_connectcloud()` — reads `CONNECT_CLOUD_{ACCOUNT,CLIENT_ID,CLIENT_SECRET}`, calls `connectCloudClientCredentials()`
+
+`updateShiny()` resolves the backend, calls the matching authenticator, then
+proceeds to the existing save-and-`deployApp()` logic unchanged.
+
+**Why a seam rather than a straight replacement:** it allows both backends to be
+live simultaneously, so Connect Cloud can be validated against the real
+simulation pipeline while shinyapps.io continues serving production. Rollback is
+an environment-variable flip, not a code revert. The seam is deliberately
+minimal — two functions and a `switch()`, no plugin registry.
+
+### Credential validation moves to startup
+
+Extend the `updateScheduler.R` preflight to validate the credentials of the
+*selected* backend — including the token, which is currently unchecked. This
+converts the silent mid-loop failure into a loud startup failure.
+
+### Correctness fixes in scope
+
+Both are in the file being modified and are the exact failure class a migration
+provokes:
+
+1. Wrap the CWD restore in `on.exit(setwd(curr_wd), add = TRUE)` so a failed
+   deploy cannot corrupt subsequent loop iterations.
+2. Replace the hardcoded `directory` default (`updateShiny.R:3-7`), which points
+   at a `Dropbox-CSDataScience` path that does not exist in this checkout, with
+   a repo-relative default.
+
+Explicitly **out of scope**: the redeploy-per-cycle architecture, `app.R`
+changes, and the stale `tests/container-shiny.yaml` / `docs/GITHUB_ACTIONS_CONFIG.md`
+cleanup beyond removing now-wrong shinyapps references.
+
+## Open questions requiring empirical verification
+
+Posit's documentation does not answer these; the plan resolves them by testing
+rather than assuming.
+
+1. **Deployment rate limit.** `updateScheduler.R:80` schedules a loop every 2
+   minutes from 14:45–22:45 — up to ~241 full-bundle redeploys per matchday.
+   No rate limit is documented anywhere for Connect Cloud. This is the largest
+   residual risk. If a limit exists, the mitigation is to gate redeploys on a
+   content hash of the results (skip deploy when unchanged), which is a
+   worthwhile change regardless.
+2. **Migration-tool behaviour for rsconnect-deployed apps.** Posit's docs
+   describe GitHub-centric flows; behaviour for an app published via
+   `deployApp()` bundles is unstated.
+3. **`connectCloudClientCredentials` availability in practice.** It appears in
+   the rsconnect reference but not in the Connect Cloud "What's New" changelog.
+
+## Testing strategy
+
+`tests/testthat/test-updateShiny-env.R` currently covers only missing-credential
+hard-fails for shinyapps.io. Extend it to cover both backends:
+
+- shinyapps backend: missing token / missing secret still hard-fail (regression)
+- connectcloud backend: missing client id / client secret / account hard-fail
+- backend selection: unknown `SHINY_DEPLOY_TARGET` fails with an actionable message
+- default remains `shinyapps` when the variable is unset (no behaviour change)
+- CWD is restored even when the deploy step throws (`on.exit` regression test)
+
+All assertions fire before any network call, so no rsconnect mocking is needed —
+matching the existing test's approach of passing `directory = tempdir()`.
+
+Manual verification gate: one real Connect Cloud deploy triggered from a local R
+session with `SHINY_DEPLOY_TARGET=connectcloud`, confirming the app renders and
+reads its bundled `data/Ergebnis.Rds`.
+
+## Timeline
+
+Migration tool ships September 2026; hard deadline 2027-03-31, which falls
+mid-Rückrunde. The work should land in the summer break, where a failed deploy
+affects nobody. Sequence: implement the seam now → validate against Connect
+Cloud when the tool ships in September → flip the default → decommission the
+shinyapps path once stable.
+
+## Rejected alternatives
+
+**Wait for automatic migration (2027-03-31).** Zero work now, but the cutover
+lands mid-season and the failure is silent (redirect works, deploys fail, data
+ages). Worst combination of bad timing and low observability.
+
+**Leave the platform** (self-hosted Shiny in the container, or static
+pre-rendered output). Solves the dependency permanently but is a separate
+project, and discards a plan whose price is frozen until 2029.
+
+## References
+
+- Announcement: <https://posit.co/blog/migrating-connect-cloud-posits-unified-publishing-solution>
+- Migration guide: <https://docs.posit.co/shinyapps.io/guide/migration/>
+- `connectCloudClientCredentials`: <https://rstudio.github.io/rsconnect/reference/connectCloudClientCredentials.html>
+- rsconnect NEWS: <https://cran.r-project.org/web/packages/rsconnect/news/news.html>
+- Connect Cloud plans: <https://docs.posit.co/connect-cloud/user/account/plans.html>

--- a/docs/superpowers/specs/2026-07-26-connect-cloud-migration-design.md
+++ b/docs/superpowers/specs/2026-07-26-connect-cloud-migration-design.md
@@ -1,8 +1,16 @@
 # Connect Cloud Migration — Design
 
 **Date:** 2026-07-26
-**Status:** Approved design, pending implementation
+**Status:** **SUPERSEDED** by [`2026-07-26-static-site-generation-design.md`](2026-07-26-static-site-generation-design.md) — do not implement
 **Trigger:** Posit email 2026-07-26 announcing shinyapps.io consolidation into Posit Connect Cloud
+
+> **Why superseded:** this design assumed hosted Shiny was worth keeping. It is
+> not — the app serves a 5.4 KB payload with no reactivity across three fixed
+> views, and the simulator already runs self-hosted in the operator's homelab,
+> so serving three static pages there costs nothing. Static generation removes
+> the migration, the credentials, the rate-limit risk and the 13 USD/month
+> entirely. Kept for the platform research (auth mechanisms, version floors,
+> plan mapping), which remains accurate.
 
 ## Problem
 

--- a/docs/superpowers/specs/2026-07-26-static-site-generation-design.md
+++ b/docs/superpowers/specs/2026-07-26-static-site-generation-design.md
@@ -1,0 +1,175 @@
+# Static Site Generation — Design
+
+**Date:** 2026-07-26
+**Status:** Approved design, supersedes `2026-07-26-connect-cloud-migration-design.md`
+**Trigger:** Posit retires shinyapps.io; the simulator already runs self-hosted in the operator's homelab
+
+## Problem
+
+The Shiny app is hosted on shinyapps.io (Starter plan, 13 USD/month), which Posit
+is retiring — paid accounts are force-migrated on 2027-03-31. Migrating to
+Connect Cloud would keep the cost and add an OAuth service-account migration.
+
+Investigating what shinyapps.io actually provides revealed that the hosted Shiny
+runtime buys almost nothing:
+
+| Property | Measured |
+|---|---|
+| Data payload (`ShinyApp/data/Ergebnis.Rds`) | **5.4 KB** |
+| Reactivity | none — no `reactive()`, no `observe()`, no session use, no writes |
+| Distinct views | **three**, selected by one `selectInput` (`input$Liga`) |
+| Data load timing | at app **startup** (`app.R:19`), not reactive |
+
+Because data is read at startup rather than reactively, viewers with an open
+session do not see new results until shinyapps.io recycles the process. The
+server-side runtime therefore provides no interactivity that a static page
+cannot.
+
+Meanwhile the deployment path is grossly disproportionate: `updateShiny.R`
+ships 5.4 KB of new data by **redeploying and restarting the entire
+application**, up to ~241 times per matchday (`updateScheduler.R:80`, a loop
+every 2 minutes from 14:45–22:45).
+
+The simulator already runs 24/7 in the operator's homelab during the season, so
+the marginal cost of serving three static pages from the same machine is
+effectively zero.
+
+## Solution
+
+Replace the hosted Shiny app with **static pre-rendering**. After each
+simulation cycle, render the three league views to self-contained HTML plus PNG
+plots into an output directory. Any web server (Caddy, nginx) serves that
+directory.
+
+This eliminates: Shiny at runtime, `rsconnect`, the deployment credentials, the
+Connect Cloud migration, the 2027-03-31 deadline, the undocumented deploy
+rate-limit risk, and the 13 USD/month cost.
+
+### Architecture
+
+One new module, `RCode/generate_static_site.R`, exposing:
+
+```r
+generate_static_site(Ergebnis, Ergebnis2, Ergebnis3, Ergebnis3_Aufstieg,
+                     output_dir, now = Sys.time())
+```
+
+It writes:
+
+```
+<output_dir>/
+├── index.html            # Bundesliga (canonical entry point)
+├── 2-bundesliga.html
+├── 3-liga.html
+└── assets/
+    ├── bundesliga.png
+    ├── 2-bundesliga.png
+    └── 3-liga.png
+```
+
+Navigation replaces the dropdown with three links present on every page, with
+the current league marked. This is the one user-visible change.
+
+**Reuse, don't reimplement.** The three rendering primitives already exist and
+are already unit-tested: `display_result()` (heatmap, `app.R:31-76`),
+`prozent()` (`app.R:78-91`), and `groupResultsDF()` (`app.R:93-122`). They are
+currently trapped inside `app.R`. Move them verbatim into
+`RCode/render_helpers.R` so both the static generator and the existing tests can
+source them. `ShinyApp/app_helpers.R` (`load_results`, `data_age_hours`,
+`stale_warning_text`) is reused unchanged.
+
+### Per-league configuration
+
+The three leagues are **not symmetric** — this is the detail most likely to be
+got wrong, so it is specified exhaustively. Note especially that 3. Liga draws
+its top table from `Ergebnis3_Aufstieg` but its bottom table and heatmap from
+`Ergebnis3`.
+
+| | Bundesliga | 2. Bundesliga | 3. Liga |
+|---|---|---|---|
+| Page | `index.html` | `2-bundesliga.html` | `3-liga.html` |
+| Heatmap source | `Ergebnis` | `Ergebnis2` | `Ergebnis3` |
+| Heatmap `Teams` | 18 | 18 | 20 |
+| Heatmap title | `Saisonprognose Bundesliga` | `Saisonprognose 2. Bundesliga` | `Saisonprognose 3. Liga` |
+| Top table source | `Ergebnis` | `Ergebnis2` | **`Ergebnis3_Aufstieg`** |
+| Top table filter | `rowSums(x[,1:6]) >= 0.01` | `rowSums(x[,1:3]) >= 0.01` | `rowSums(x[,1:4]) >= 0.01` |
+| Top table labels | Meister, Champions League, Europa League, Conference League Quali | Aufstieg, Relegation Bundesliga | Aufstieg, Relegation, DFB-Pokal |
+| Top table groups | `cbind(c(1,1),c(2,4),c(5,5),c(6,6))` | `cbind(c(1,2),c(3,3))` | `cbind(c(1,2),c(3,3),c(4,4))` |
+| Bottom table source | `Ergebnis` | `Ergebnis2` | `Ergebnis3` |
+| Bottom table filter | `rowSums(x[,16:18]) >= 0.01` | `rowSums(x[,16:18]) >= 0.01` | `rowSums(x[,17:20]) >= 0.01` |
+| Bottom table labels | Relegation, Abstieg | Relegation 3. Liga, Abstieg | Abstieg |
+| Bottom table groups | `cbind(c(16,16),c(17,18))` | `cbind(c(16,16),c(17,18))` | `cbind(c(17,20))` |
+
+Data shapes, verified from the live file: `Ergebnis` 18×18, `Ergebnis2` 18×18,
+`Ergebnis3` 20×20, `Ergebnis3_Aufstieg` 20×20 (all class `table`).
+
+### Behaviour preserved from the Shiny app
+
+- **Footer timestamp** with DST-correct label: `MESZ` when `updatetime$isdst > 0`,
+  else `MEZ` (`app.R:160-165`). Existing test
+  `tests/testthat/test-shiny-footer-timezone.R` covers this logic and currently
+  duplicates the expression by hand; the static generator should use the shared
+  helper so the duplication ends.
+- **Stale-data banner** past 24 hours, via `stale_warning_text()`.
+- **Graceful degradation**: when results cannot be loaded, emit a page carrying
+  the existing "Noch keine Prognosedaten verfügbar" message rather than failing.
+- Title "Fußball-Prognosen von 30Punkte" and the `30punkte.wordpress.com` link.
+
+### Integration
+
+`RCode/update_all_leagues_loop.R:163-169` currently calls `updateShiny()` behind
+a `simulation_executed && !is.null(Ergebnis)` gate. Replace that call with
+`generate_static_site()`, keeping the gate. Output directory comes from
+`STATIC_SITE_DIR` (default `ShinyApp/public`), mounted as a volume so the web
+server sees it.
+
+Writing 5.4 KB of local files is cheap and idempotent, so the redeploy-frequency
+concern disappears entirely — no hash-gating needed.
+
+## Out of scope
+
+- The `RAPIDAPI_KEY` / simulation pipeline — untouched.
+- Web server, TLS, and public routing (Caddy/Cloudflare Tunnel) — operator
+  infrastructure, documented but not automated here.
+- Deleting `ShinyApp/app.R`. It stays as a local development tool and rollback
+  path until the static site has run one full matchday. Retiring it is a
+  follow-up.
+
+## Testing strategy
+
+`display_result`, `prozent`, and `groupResultsDF` move to
+`RCode/render_helpers.R` unchanged, so existing tests keep passing —
+`tests/testthat/test-prozent.R` and `test-shiny-app-helpers.R` are the
+regression net for the move.
+
+New tests for `generate_static_site()`, using the real 5.4 KB fixture:
+
+- writes all four expected files (three HTML + `assets/` PNGs)
+- each page contains its league's title and all three navigation links
+- the Bundesliga page's top table contains the expected group labels
+- 3. Liga's top table is built from `Ergebnis3_Aufstieg`, its bottom from
+  `Ergebnis3` (guards the asymmetry)
+- footer renders `MESZ` for a summer timestamp and `MEZ` for a winter one
+- stale banner appears for a 30-hour-old timestamp, absent for a fresh one
+- missing/corrupt data produces the fallback page and does not error
+- output is deterministic: two runs with the same inputs and fixed `now`
+  produce byte-identical HTML
+
+Manual gate: open the generated `index.html` in a browser, confirm all three
+pages render heatmaps and tables and that navigation works.
+
+## Rollback
+
+`ShinyApp/app.R` remains functional and shinyapps.io stays live until the static
+site has served one full matchday. Rollback is reverting the one call site in
+`update_all_leagues_loop.R`.
+
+## Migration sequence
+
+1. Implement and test the generator (no production change).
+2. Run it alongside the existing deploy for one matchday; compare output against
+   the live Shiny app.
+3. Point the homelab web server at the output directory.
+4. Switch the call site; stop deploying to shinyapps.io.
+5. Cancel the shinyapps.io subscription — well before 2027-03-31, so the forced
+   migration never applies.


### PR DESCRIPTION
Collects documentation work that existed only in the local working tree and never reached GitHub.

## Contents

**Deployment migration (Jul 2026)**
- Design + implementation plan for the shinyapps.io → Connect Cloud migration
- Design + implementation plan for static site generation (replacing hosted Shiny)
- The Connect Cloud docs are marked superseded by the static-site approach

**Earlier 2026 review work (previously untracked)**
- PRDs for the deployment-surface collapse and the simulation-engine seam
- Matching implementation plans
- Season-transition test-coverage plan
- Codebase review findings

## Also

Adds `.gitignore` entries for operator run artifacts — season backup archives, `logs/`, processing logs, and `testthat-summary.txt` — so they stop appearing as untracked noise. No files are removed from disk.

Documentation only; no code or behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)